### PR TITLE
fix: check string for null terminators

### DIFF
--- a/src/matroska/ebml.ts
+++ b/src/matroska/ebml.ts
@@ -499,7 +499,13 @@ export class EBMLReader {
 		const { view, offset } = this.reader.getViewAndOffset(this.pos, this.pos + length);
 		this.pos += length;
 
-		return String.fromCharCode(...new Uint8Array(view.buffer, offset, length));
+		// Actual string length might be shorter due to null terminators
+		let strLength = 0;
+		while (strLength < length && view.getUint8(offset + strLength) !== 0) {
+			strLength += 1;
+		}
+
+		return String.fromCharCode(...new Uint8Array(view.buffer, offset, strLength));
 	}
 
 	readElementId() {


### PR DESCRIPTION
This PR adds a check for null terminators when reading strings in an EBML header.

I found an issue when I was trying to load the following .webm file:
[Screencast from 2025-08-07 11-12-28.webm](https://github.com/user-attachments/assets/10fd403b-a794-454d-bf7b-d23df5f898c3)

Turns out it's because the doctype contains the string `webm\0` (with a null terminator at the end)

According to the EBML spec (https://github.com/ietf-wg-cellar/ebml-specification/blob/master/specification.markdown#terminating-elements), terminating elements might be present in a string element:
> The Element Data of a UTF-8 Element MUST be a valid UTF-8 string up to whichever comes first: the end of the Element or the first occurring Null octet. Within the Element Data of a String or UTF-8 Element, any Null octet itself and any following data within that Element SHOULD be ignored.