### PR TITLE
fix(conversion): fixed using wrong timestamp

### DIFF
--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -757,7 +757,7 @@ export class Conversion {
 						}
 
 						let adjustedSampleTimestamp = Math.max(sample.timestamp - this._startTimestamp, 0);
-						lastSampleEndTimestamp = sample.timestamp + sample.duration;
+						lastSampleEndTimestamp = adjustedSampleTimestamp + sample.duration;
 
 						if (frameRate !== undefined) {
 							// Logic for skipping/repeating frames when a frame rate is set

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -671,7 +671,7 @@ export class Conversion {
 						}
 
 						let adjustedSampleTimestamp = Math.max(timestamp - this._startTimestamp, 0);
-						lastCanvasEndTimestamp = timestamp + duration;
+						lastCanvasEndTimestamp = adjustedSampleTimestamp + duration;
 
 						if (frameRate !== undefined) {
 							// Logic for skipping/repeating frames when a frame rate is set


### PR DESCRIPTION
The original logic `lastCanvasEndTimestamp = timestamp + duration;` uses the timestamp of the original frame, but `padFrames` calculates the difference between it and `lastCanvasTimestamp`. This will result in an incorrect end time. For example, when trimming a video to [10, 20], the final video will be 20s instead of 10s.