### PR TITLE
Fix UrlSource single-byte buffer on Range Request HTTP 200

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -316,6 +316,8 @@ export class UrlSource extends Source {
 			this._fullData = await rangeResponse.arrayBuffer();
 			if (this._fullData.byteLength !== 1) {
 				return this._fullData.byteLength;
+			} else {
+				// The server responded with 200, but returned only the requested range, so skip the response
 			}
 		}
 


### PR DESCRIPTION
## Issue
When loading a video though the `UrlSource` Source, the following error would appear: `Input has an unsupported or unrecognizable format.`

## Solution
Unsure on where exactly the error was first introduced, in `source.js`, in function `_retrieveSize `of `UrlSource`, when performing a successful **Range Request** (HTTP 200), the header `Content-Range` buffer size would equate to **1**, fix was to skip it and force a full GET request.