### PR TITLE
fix: infinite loop in IsobmffTrackBacking when processing fragments

### DIFF
--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -2382,6 +2382,10 @@ abstract class IsobmffTrackBacking implements InputTrackBacking {
 					if (prevFragment.nextFragment) {
 						// Skip ahead quickly without needing to read the file again
 						metadataReader.pos = prevFragment.nextFragment.moofOffset + prevFragment.nextFragment.moofSize;
+						if (prevFragment.nextFragment === prevFragment) {
+							// prevent infinite while loop
+							break;
+						}
 						prevFragment = prevFragment.nextFragment;
 						continue;
 					}


### PR DESCRIPTION
Fix:
- #70 

---

TBH I am more curious about how does `nextFragment` become self linked in the first place