### PR TITLE
Match Prettier style

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
     "audio",
     "subtitles",
     "webcodecs"
-  ]
+  ],
+  "prettier": {
+    "singleQuote": true
+  }
 }


### PR DESCRIPTION
This way, people who have Prettier as their default formatter in their Editor (probably the majority of people) will not have the code re-formatted to double quotes if they are saving