### PR TITLE
Enable ESLint as formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-	"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+	"editor.defaultFormatter": "dbaeumer.vscode-eslint",
+	"eslint.format.enable": true
 }


### PR DESCRIPTION
I was working on a different computer today, and the formatting on save did not work out of the box for me.

I had to manually enable this setting, most people have it probably but explicitly enabling it for this project makes it easier for contributors.