### PR TITLE
Fix tfdt logic

### DIFF
--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -1208,7 +1208,7 @@ export const tfdt = (trackData: IsobmffTrackData) => {
 	assert(trackData.currentChunk);
 
 	return fullBox('tfdt', 1, 0, [
-		u64(intoTimescale(trackData.currentChunk.startTimestamp, trackData.timescale)), // Base Media Decode Time
+		u64(intoTimescale(trackData.currentChunk.startDecodeTimestamp, trackData.timescale)), // Base Media Decode Time
 	]);
 };
 

--- a/src/isobmff/isobmff-muxer.ts
+++ b/src/isobmff/isobmff-muxer.ts
@@ -50,6 +50,7 @@ export type Sample = {
 type Chunk = {
 	/** The lowest presentation timestamp in this chunk */
 	startTimestamp: number;
+	startDecodeTimestamp: number;
 	samples: Sample[];
 	offset: number | null;
 	// In the case of a fragmented file, this indicates the position of the moof box pointing to the data in this chunk
@@ -889,6 +890,7 @@ export class IsobmffMuxer extends Muxer {
 
 			trackData.currentChunk = {
 				startTimestamp: sample.timestamp,
+				startDecodeTimestamp: sample.decodeTimestamp,
 				samples: [],
 				offset: null,
 				moofOffset: null,


### PR DESCRIPTION
By definition, Track Fragment Base Media "Decode" Time.

It is currently problematic with convert to fmp4.
1. `MediaSource`, `SourceBuffer.mode = 'segments'`: When there is b-frame, using PTS (e.g. 24fps, 2 b-frame, 0.08333) could result in `buffered` range gap that `<video>` get stuck.
2. The result fmp4 file duration would also be longer by an extra first PTS amount.