### PR TITLE
Experimental WebM alpha support

### DIFF
--- a/dev/convert.html
+++ b/dev/convert.html
@@ -5,6 +5,8 @@
 
 <script type="module">
 	MediabunnyMp3Encoder.registerMp3Encoder();
+	Mediabunny.registerWebMSeparateAlphaDecoder();
+	Mediabunny.registerWebMSeparateAlphaEncoder();
 
 	const fileInput = document.createElement('input');
 	fileInput.type = 'file';
@@ -97,7 +99,8 @@
 			*/
 			/*
 			video: {
-				codec: 'avc',
+				codec: 'vp9',
+				alpha: 'keep',
 			},
 			audio: {
 				codec: 'mp3',

--- a/docs/guide/media-sources.md
+++ b/docs/guide/media-sources.md
@@ -74,7 +74,8 @@ type VideoEncodingConfig = {
 - `hardwareAcceleration`: A hint that configures the hardware acceleration method of this codec. This is best left on `'no-preference'`.
 - `scalabilityMode`: An encoding scalability mode identifier as defined by [WebRTC-SVC](https://w3c.github.io/webrtc-svc/#scalabilitymodes*).
 - `contentHint`: An encoding video content hint as defined by [mst-content-hint](https://w3c.github.io/mst-content-hint/#video-content-hints).
-- `sizeChangeBehavior`: Video frames may change size overtime. This field controls the behavior in case this happens. Defaults to `'deny'`. 
+- `sizeChangeBehavior`: Video frames may change size overtime. This field controls the behavior in case this happens. Defaults to `'deny'`.
+- `alpha`: Alpha option defined by [alpha-option](https://w3c.github.io/webcodecs/#alpha-option). Defaults to `'discard'`.
 - `onEncodedPacket`: Called for each successfully encoded packet. Useful for determining encoding progress.
 - `onEncoderConfig`: Called when the internal encoder config, as used by the WebCodecs API, is created. You can use this to introspect the full codec string.
 

--- a/docs/guide/packets-and-samples.md
+++ b/docs/guide/packets-and-samples.md
@@ -91,6 +91,7 @@ constructor(
     duration: number, // in seconds
     sequenceNumber?: number,
     byteLength?: number,
+    additions?: Uint8Array, // Additional data, currently only for Matroska format
 );
 ```
 

--- a/docs/guide/supported-formats-and-codecs.md
+++ b/docs/guide/supported-formats-and-codecs.md
@@ -339,15 +339,14 @@ Issues examples:
 ### Encoding WebM with alpha channel
 
 Support can be added with `registerWebMSeparateAlphaEncoder`.
-Then, opt in with `videoEncodingConfig.alpha = 'keep'` on AV1/VP9/VP8 codecs.
+Then, opt in with `videoEncodingConfig.alpha = 'keep'` on VP9/VP8 codecs.
 
 ::: info
-While AV1 with alpha muxing works, browsers wouldn't decode alpha natively in browser.
-Also, Safari does not support WebM alpha native.
+Safari does not support WebM alpha natively.
 :::
 ::: warning
 The alpha channel support is part of WebM file format and useful to do alpha encoding process in the **WebM/MKV format only**.
-While it should not cause problem to opt-in for 'keep' in other formats, the alpha would be wasteful in other formats.
+While it should not cause problem to opt-in for 'keep' in other formats, the alpha processing would be wasteful in other formats.
 :::
 
 ### Decoding WebM with alpha channel

--- a/docs/guide/supported-formats-and-codecs.md
+++ b/docs/guide/supported-formats-and-codecs.md
@@ -332,7 +332,9 @@ A set of custom coders is provided to support it by separately handle the alpha 
 It is experimental and still requires more work on the main library and CustomCoder APIs.
 Issues examples:
 - No proper way for user to confirm if a file is indeed a WebM with alpha and thus if opt-in support is needed.
-- CustomCoder supports detection is not specific enough with current abstraction.
+- Limitations with current abstraction.
+- Poor performance on Firefox.
+- Does not support Safari.
 :::
 
 ### Encoding WebM with alpha channel

--- a/docs/guide/supported-formats-and-codecs.md
+++ b/docs/guide/supported-formats-and-codecs.md
@@ -334,7 +334,6 @@ Issues examples:
 - No proper way for user to confirm if a file is indeed a WebM with alpha and thus if opt-in support is needed.
 - Limitations with current abstraction.
 - Poor performance on Firefox.
-- Does not support Safari.
 :::
 
 ### Encoding WebM with alpha channel
@@ -343,11 +342,12 @@ Support can be added with `registerWebMSeparateAlphaEncoder`.
 Then, opt in with `videoEncodingConfig.alpha = 'keep'` on AV1/VP9/VP8 codecs.
 
 ::: info
-While AV1 with alpha muxing works, browsers wouldn't decode natively in browser.
+While AV1 with alpha muxing works, browsers wouldn't decode alpha natively in browser.
+Also, Safari does not support WebM alpha native.
 :::
 ::: warning
-The alpha channel support is part of WebM file format and useful to encode in the **WebM/MKV muxer only**.
-While it should not cause problem to opt-in for 'keep' in other formats, the alpha would still be discarded in other formats.
+The alpha channel support is part of WebM file format and useful to do alpha encoding process in the **WebM/MKV format only**.
+While it should not cause problem to opt-in for 'keep' in other formats, the alpha would be wasteful in other formats.
 :::
 
 ### Decoding WebM with alpha channel

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -141,6 +141,8 @@ export type ConversionVideoOptions = {
 	bitrate?: number | Quality;
 	/** When `true`, video will always be re-encoded instead of directly copying over the encoded samples. */
 	forceTranscode?: boolean;
+	/** Alpha channel setting */
+	alpha?: VideoEncodingConfig['alpha'];
 };
 
 /**
@@ -218,6 +220,12 @@ const validateVideoOptions = (videoOptions: ConversionVideoOptions | undefined) 
 		&& (!Number.isFinite(videoOptions.frameRate) || videoOptions.frameRate <= 0)
 	) {
 		throw new TypeError('options.video.frameRate, when provided, must be a finite positive number.');
+	}
+	if (
+		videoOptions?.alpha !== undefined
+		&& !['keep', 'discard'].includes(videoOptions.alpha)
+	) {
+		throw new TypeError('options.video.alpha must be one of "keep" or "discard".');
 	}
 };
 
@@ -698,6 +706,7 @@ export class Conversion {
 				bitrate,
 				sizeChangeBehavior: trackOptions.fit ?? 'passThrough',
 				onEncodedPacket: sample => this._reportProgress(track.id, sample.timestamp + sample.duration),
+				alpha: trackOptions.alpha,
 			};
 
 			const source = new VideoSampleSource(encodingConfig);

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -130,6 +130,11 @@ export type VideoEncodingAdditionalOptions = {
 	 * [mst-content-hint](https://w3c.github.io/mst-content-hint/#video-content-hints).
 	 */
 	contentHint?: string;
+	/**
+	 * Alpha option defined by
+	 * [alpha-option](https://w3c.github.io/webcodecs/#alpha-option).
+	 */
+	alpha?: VideoEncoderConfig['alpha'];
 };
 
 export const validateVideoEncodingAdditionalOptions = (codec: VideoCodec, options: VideoEncodingAdditionalOptions) => {
@@ -194,6 +199,7 @@ export const buildVideoEncoderConfig = (options: {
 		hardwareAcceleration: options.hardwareAcceleration,
 		scalabilityMode: options.scalabilityMode,
 		contentHint: options.contentHint,
+		alpha: options.alpha,
 		...getVideoEncoderConfigExtension(options.codec),
 	};
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,5 +193,9 @@ export {
 	AttachedImage,
 	RichImageData,
 } from './tags';
+export {
+	registerWebMSeparateAlphaDecoder,
+	registerWebMSeparateAlphaEncoder,
+} from './webm-alpha';
 
 // 🐡🦔

--- a/src/matroska/ebml.ts
+++ b/src/matroska/ebml.ts
@@ -97,6 +97,7 @@ export enum EBMLId {
 	SeekPreRoll = 0x56bb,
 	DefaultDuration = 0x23e383,
 	Video = 0xe0,
+	AlphaMode = 0x53c0,
 	PixelWidth = 0xb0,
 	PixelHeight = 0xba,
 	Audio = 0xe1,

--- a/src/matroska/matroska-demuxer.ts
+++ b/src/matroska/matroska-demuxer.ts
@@ -2203,6 +2203,7 @@ class MatroskaVideoTrackBacking extends MatroskaTrackBacking implements InputVid
 				customAlphaDecoderRegistered
 				&& this.internalTrack.info.alphaMode
 				&& firstPacket?.additions
+				&& typeof VideoEncoder !== 'undefined'
 				&& (await VideoDecoder.isConfigSupported(configWithPreferSoftware)).supported
 			) {
 				return configWithPreferSoftware;

--- a/src/matroska/matroska-demuxer.ts
+++ b/src/matroska/matroska-demuxer.ts
@@ -2155,6 +2155,7 @@ class MatroskaVideoTrackBacking extends MatroskaTrackBacking implements InputVid
 		return this.decoderConfigPromise ??= (async (): Promise<VideoDecoderConfig> => {
 			let firstPacket: EncodedPacket | null = null;
 			const needsAlphaSupportChecking = this.internalTrack.info.alphaMode
+				&& ['vp9', 'av1', 'vp8'].includes(this.internalTrack.info.codec || '')
 				&& isWebMSeparateAlphaDecoderRegistered();
 			const needsPacketForAdditionalInfo
 				= this.internalTrack.info.codec === 'vp9'

--- a/src/matroska/matroska-muxer.ts
+++ b/src/matroska/matroska-muxer.ts
@@ -340,9 +340,9 @@ export class MatroskaMuxer extends Muxer {
 
 		const colorSpace = trackData.info.decoderConfig.colorSpace;
 		const videoElement: EBMLElement = { id: EBMLId.Video, data: [
-			(trackData.info.alphaMode ? { id: EBMLId.AlphaMode, data: 1 } : null),
 			{ id: EBMLId.PixelWidth, data: trackData.info.width },
 			{ id: EBMLId.PixelHeight, data: trackData.info.height },
+			(trackData.info.alphaMode ? { id: EBMLId.AlphaMode, data: 1 } : null),
 			(colorSpaceIsComplete(colorSpace)
 				? {
 						id: EBMLId.Colour,
@@ -1058,8 +1058,8 @@ export class MatroskaMuxer extends Muxer {
 				chunk.additions
 					? { id: EBMLId.BlockAdditions, data: [
 							{ id: EBMLId.BlockMore, data: [
-								{ id: EBMLId.BlockAdditional, data: chunk.additions },
 								{ id: EBMLId.BlockAddID, data: 1 },
+								{ id: EBMLId.BlockAdditional, data: chunk.additions },
 							] },
 						] }
 					: null,

--- a/src/matroska/matroska-muxer.ts
+++ b/src/matroska/matroska-muxer.ts
@@ -87,6 +87,7 @@ type MatroskaTrackData = {
 		width: number;
 		height: number;
 		decoderConfig: VideoDecoderConfig;
+		alphaMode?: boolean;
 	};
 } | {
 	track: OutputAudioTrack;
@@ -339,6 +340,7 @@ export class MatroskaMuxer extends Muxer {
 
 		const colorSpace = trackData.info.decoderConfig.colorSpace;
 		const videoElement: EBMLElement = { id: EBMLId.Video, data: [
+			(trackData.info.alphaMode ? { id: EBMLId.AlphaMode, data: 1 } : null),
 			{ id: EBMLId.PixelWidth, data: trackData.info.width },
 			{ id: EBMLId.PixelHeight, data: trackData.info.height },
 			(colorSpaceIsComplete(colorSpace)
@@ -788,8 +790,19 @@ export class MatroskaMuxer extends Muxer {
 				duration = roundToMultiple(duration, 1 / track.metadata.frameRate);
 			}
 
-			const videoChunk = this.createInternalChunk(packet.data, timestamp, duration, packet.type);
+			const videoChunk = this.createInternalChunk(
+				packet.data,
+				timestamp,
+				duration,
+				packet.type,
+				packet.additions,
+			);
 			if (track.source._codec === 'vp9') this.fixVP9ColorSpace(trackData, videoChunk);
+			if (videoChunk.additions) {
+				trackData.info.alphaMode ??= true; // All samples should contain it consistently
+			} else {
+				trackData.info.alphaMode = false;
+			}
 
 			trackData.chunkQueue.push(videoChunk);
 			await this.interleaveChunks();

--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -1129,6 +1129,7 @@ export class CanvasSink {
 	/** @internal */
 	_videoSampleToWrappedCanvas(sample: VideoSample): WrappedCanvas {
 		let canvas = this._canvasPool[this._nextCanvasIndex];
+		let canvasIsNew = false;
 		const alpha = sample.format === null // Weird: HEVC with alpha, Chromium v139
 			|| sample.format?.includes('A');
 
@@ -1140,6 +1141,8 @@ export class CanvasSink {
 				canvas.height = this._height;
 			} else {
 				canvas = new OffscreenCanvas(this._width, this._height);
+
+				canvasIsNew = true;
 			}
 
 			if (this._canvasPool.length > 0) {
@@ -1156,7 +1159,10 @@ export class CanvasSink {
 		assert(context);
 
 		context.resetTransform();
-		context.globalCompositeOperation = 'copy';
+
+		if (!canvasIsNew || alpha) {
+			context.clearRect(0, 0, this._width, this._height);
+		}
 
 		sample.drawWithFit(context, {
 			fit: this._fit,

--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -1141,13 +1141,13 @@ export class CanvasSink {
 				canvas.height = this._height;
 			} else {
 				canvas = new OffscreenCanvas(this._width, this._height);
-
-				canvasIsNew = true;
 			}
 
 			if (this._canvasPool.length > 0) {
 				this._canvasPool[this._nextCanvasIndex] = canvas;
 			}
+
+			canvasIsNew = true;
 		}
 
 		if (this._canvasPool.length > 0) {

--- a/src/media-source.ts
+++ b/src/media-source.ts
@@ -233,6 +233,7 @@ class VideoEncoderWrapper {
 							+ ` encoding options.`,
 						);
 					} else {
+						let canvasIsNew = false;
 						const alpha = videoSample.format === null // Weird: HEVC with alpha, Chromium v139
 							|| videoSample.format?.includes('A');
 
@@ -245,13 +246,17 @@ class VideoEncoderWrapper {
 							} else {
 								this.resizeCanvas = new OffscreenCanvas(this.codedWidth, this.codedHeight);
 							}
+
+							canvasIsNew = true;
 						}
 
 						const context = this.resizeCanvas.getContext('2d', { alpha }) as
 							CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 						assert(context);
 
-						context.globalCompositeOperation = 'copy';
+						if (!canvasIsNew) {
+							context.clearRect(0, 0, this.codedWidth, this.codedHeight);
+						}
 
 						videoSample.drawWithFit(context, { fit: sizeChangeBehavior });
 

--- a/src/media-source.ts
+++ b/src/media-source.ts
@@ -408,7 +408,7 @@ class VideoEncoderWrapper {
 
 					if (
 						this.encodingConfig.alpha === 'keep'
-						&& ['vp9', 'av1', 'vp8'].includes(this.encodingConfig.codec)
+						&& ['vp9', 'vp8'].includes(this.encodingConfig.codec)
 						&& ['video/webm', 'x-matroska'].includes(
 							this.source._connectedTrack?.output.format.mimeType || '',
 						)

--- a/src/packet.ts
+++ b/src/packet.ts
@@ -54,6 +54,8 @@ export class EncodedPacket {
 		 */
 		public readonly sequenceNumber = -1,
 		byteLength?: number,
+		/** Additional data for the packet, currently used only for Matroska custom encoding/decoding behaviors */
+		public readonly additions?: Uint8Array,
 	) {
 		if (data === PLACEHOLDER_DATA && byteLength === undefined) {
 			throw new Error(
@@ -180,6 +182,7 @@ export class EncodedPacket {
 			options?.duration ?? this.duration,
 			this.sequenceNumber,
 			this.byteLength,
+			this.additions,
 		);
 	}
 }

--- a/src/webm-alpha.ts
+++ b/src/webm-alpha.ts
@@ -141,6 +141,7 @@ const combineAlpha = async (main: VideoFrame, alpha?: VideoFrame | null | void) 
 		displayHeight: main.displayHeight,
 		colorSpace: main.colorSpace,
 		timestamp: main.timestamp,
+		duration: main.duration,
 		format: resultFormat,
 		transfer: [data.buffer],
 	} as VideoFrameBufferInit);

--- a/src/webm-alpha.ts
+++ b/src/webm-alpha.ts
@@ -1,0 +1,381 @@
+/*!
+ * Copyright (c) 2025-present, Vanilagy and contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { VideoCodec } from './codec';
+import {
+	CustomVideoDecoder,
+	customVideoDecoders,
+	CustomVideoEncoder,
+	registerDecoder,
+	registerEncoder,
+} from './custom-coder';
+import { promiseWithResolvers, assert } from './misc';
+import { EncodedPacket } from './packet';
+import { VideoSample } from './sample';
+
+class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
+	private mainCoder!: VideoDecoder;
+	private alphaCoder!: VideoDecoder;
+
+	private mainCoderError: DOMException | null = null;
+	private alphaCoderError: DOMException | null = null;
+
+	// Main output needs to wait for alpha output to be ready, or null due to unexpected issue
+	private alphaOutputResolverMap = new Map<
+		number,
+		ReturnType<typeof promiseWithResolvers<VideoFrame | null>>
+	>();
+
+	private closed = false;
+
+	static override supports(codec: VideoCodec, config: VideoDecoderConfig) {
+		// Hardware accelerated have impractically worse performance in current implementation of _combineAlpha
+		// Does not support 'prefer-hardware' now
+		return ['vp9', 'av1', 'vp8'].includes(codec)
+			&& config.hardwareAcceleration === 'prefer-software'
+			&& typeof VideoDecoder !== 'undefined'
+			&& typeof VideoFrame !== 'undefined';
+	}
+
+	override init() {
+		this.mainCoder = new VideoDecoder({
+			output: (output) => {
+				const resolver = this._getAlphaOutputResolver(output.timestamp);
+				(async () => {
+					const alpha = await resolver.promise.catch(() => {});
+					const frame = await this._combineAlpha(output, alpha);
+
+					this.onSample(new VideoSample(frame));
+				})().catch(() => {});
+			},
+
+			error: (error) => {
+				this.mainCoderError = error;
+				this.close();
+			},
+		});
+		this.mainCoder.configure(this.config);
+		this.alphaCoder = new VideoDecoder({
+			output: (output) => {
+				if (this.mainCoderError || this.alphaCoderError || this.closed) {
+					return output.close();
+				}
+
+				this._getAlphaOutputResolver(output.timestamp).resolve(output);
+			},
+			error: (error) => {
+				this.alphaCoderError = error;
+			},
+		});
+		this.alphaCoder.configure(this.config);
+	}
+
+	override decode(packet: EncodedPacket) {
+		const resolver = this._getAlphaOutputResolver(packet.microsecondTimestamp);
+
+		if (packet.additions) {
+			this.alphaCoder.decode(
+				new EncodedPacket(
+					packet.additions,
+					packet.type,
+					packet.timestamp,
+					packet.duration,
+					packet.sequenceNumber,
+				).toEncodedVideoChunk(),
+			);
+		} else {
+			resolver.resolve(null);
+		}
+
+		this.mainCoder.decode(packet.toEncodedVideoChunk());
+	}
+
+	async flush() {
+		await Promise.all([
+			this.mainCoder.flush(),
+			this.alphaCoder.flush(),
+		]);
+
+		const promises = [];
+
+		for (const resolver of this.alphaOutputResolverMap.values()) {
+			promises.push(resolver.promise);
+		}
+
+		await Promise.allSettled(promises);
+	}
+
+	override close() {
+		if (this.mainCoder.state !== 'closed') this.mainCoder.close();
+		if (this.alphaCoder.state !== 'closed') this.alphaCoder.close();
+		this.closed = true;
+	}
+
+	/** @internal */
+	_getAlphaOutputResolver(microsecondTimestamp: number) {
+		if (!this.alphaOutputResolverMap.has(microsecondTimestamp)) {
+			this.alphaOutputResolverMap.set(microsecondTimestamp, promiseWithResolvers());
+		}
+
+		const resolver = this.alphaOutputResolverMap.get(microsecondTimestamp)!;
+
+		if (this.alphaCoderError || closed) {
+			resolver.resolve(null);
+		}
+
+		return resolver;
+	}
+
+	/** @internal */
+	async _combineAlpha(main: VideoFrame, alpha?: VideoFrame | null | void) {
+		// No alpha, or closed
+		if (!alpha || alpha.displayWidth === 0) {
+			return main;
+		}
+
+		const format = main.format || '';
+		const formatPrefix = format.slice(0, 4); // e.g. I420
+		const formatAffix = format.slice(4, format.length); // e.g. P12
+
+		if (
+			formatPrefix.at(0) !== 'I' // Only support planar YUV, expected when using prefer-software
+			|| formatAffix.at(0) === 'A' // Already include alpha, ignore
+		) {
+			return main;
+		};
+
+		try {
+			const uint8 = new Uint8Array(main.allocationSize() + alpha.allocationSize());
+			const mainData = uint8.subarray(0, main.allocationSize());
+			const alphaData = uint8.subarray(main.allocationSize(), uint8.byteLength);
+
+			// Y, U, V + A (alpha's Y as A)
+			// Extra U, V data from alpha main are dummy and discarded
+			await Promise.all([
+				main.copyTo(mainData),
+				alpha.copyTo(alphaData),
+			]);
+
+			return new VideoFrame(uint8, {
+				codedWidth: main.displayWidth, // As a result of copyTo
+				codedHeight: main.displayHeight,
+				displayWidth: main.displayWidth,
+				displayHeight: main.displayHeight,
+				colorSpace: main.colorSpace,
+				timestamp: main.timestamp,
+				duration: main.duration ?? undefined,
+				format: `${formatPrefix}A${formatAffix}` as VideoPixelFormat,
+				transfer: [uint8.buffer],
+			} as VideoFrameBufferInit);
+		} finally {
+			main.close();
+			alpha?.close();
+		}
+	}
+}
+
+/**
+ * Registers the experimental custom decoder for handling supported packets with alpha channel in `VideoCodec` for WebM
+ * By internally creating 2 `VideoDecoder` to handle main color data and additional data (alpha) separately and combine.
+ * Supports `VideoDecodingConfig.hardwareAcceleration: 'prefer-software'`, also as an implicit opt-in mechanism.
+ * For convenience, registering this will make matroska-demuxer auto opt-in.
+ *
+ * ```ts
+ * import { registerWebMSeparateAlphaDecoder, type VideoDecodingConfig } from 'mediabunny';
+ *
+ * registerWebMSeparateAlphaDecoder();
+ *
+ * // Default: 'no-preference'
+ * const config: VideoDecodingConfig = { ...others, hardwareAcceleration: 'prefer-software' };
+ * ```
+ *
+ * @alpha
+ */
+export const registerWebMSeparateAlphaDecoder = () => registerDecoder(WebMSeparateAlphaDecoder);
+
+/** @internal */
+export const isWebMSeparateAlphaDecoderRegistered = () => customVideoDecoders.includes(WebMSeparateAlphaDecoder);
+
+class WebMSeparateAlphaEncoder extends CustomVideoEncoder {
+	private mainCoder!: VideoEncoder;
+	private alphaCoder!: VideoEncoder;
+
+	private mainCoderError: DOMException | null = null;
+	private alphaCoderError: DOMException | null = null;
+
+	// Main output needs to wait for alpha output to be ready, or null due to unexpected issue
+	private alphaOutputResolverMap = new Map<
+		number,
+		ReturnType<typeof promiseWithResolvers<EncodedVideoChunk | null>>
+	>();
+
+	private canvas?: OffscreenCanvas;
+
+	private closed = false;
+
+	static override supports(codec: VideoCodec, config: VideoEncoderConfig) {
+		return config.alpha === 'keep'
+			&& ['vp9', 'av1', 'vp8'].includes(codec)
+			&& typeof VideoEncoder !== 'undefined'
+			&& typeof VideoFrame !== 'undefined'
+			&& typeof OffscreenCanvas !== 'undefined';
+	}
+
+	override init() {
+		const config: VideoEncoderConfig = {
+			...this.config,
+			alpha: 'discard',
+		};
+
+		this.mainCoder = new VideoEncoder({
+			output: (chunk, metadata) => {
+				const resolver = this._getAlphaOutputResolver(chunk.timestamp);
+				const packet = EncodedPacket.fromEncodedChunk(chunk);
+
+				(async () => {
+					const alpha = await resolver.promise.catch(() => {});
+
+					if (alpha) {
+						const alphaPacket = EncodedPacket.fromEncodedChunk(alpha);
+
+						/** @ts-expect-error Technically readonly */
+						packet.additions = alphaPacket.data ?? undefined;
+					}
+					this.onPacket(packet, metadata);
+				})().catch(() => {});
+			},
+			error: (error) => {
+				this.mainCoderError = error;
+				this.close();
+			},
+		});
+		this.mainCoder.configure(config);
+
+		// Better add when there is really data and properly check configure in supports first
+		// Need refactoring of current API
+		// FIXME: problem with limited range, 0 alpha become 16...
+		this.alphaCoder = new VideoEncoder({
+			output: (chunk) => {
+				if (this.mainCoderError || this.alphaCoderError || this.closed) {
+					return;
+				}
+
+				this._getAlphaOutputResolver(chunk.timestamp).resolve(chunk);
+			},
+			error: (error) => {
+				this.alphaCoderError = error;
+			},
+		});
+		this.alphaCoder.configure(config);
+	}
+
+	override async encode(videoSample: VideoSample, options: VideoEncoderEncodeOptions) {
+		if (this.mainCoderError) {
+			/** @ts-expect-error ES target version issue? */
+			throw new Error('Cannot encode on a closed VideoEncoder', { cause: this.mainCoderError });
+		}
+
+		const alpha = await this._extractAlpha(videoSample);
+
+		if (alpha) {
+			this.alphaCoder.encode(alpha, options);
+			alpha.close();
+		} else {
+			this._getAlphaOutputResolver(videoSample.microsecondTimestamp).resolve(null);
+		}
+
+		const frame = videoSample.toVideoFrame();
+
+		this.mainCoder.encode(frame, options);
+		frame.close();
+	}
+
+	async flush() {
+		await Promise.all([
+			this.mainCoder.flush(),
+			this.alphaCoder.flush(),
+		]);
+
+		const promises = [];
+
+		for (const resolver of this.alphaOutputResolverMap.values()) {
+			promises.push(resolver.promise);
+		}
+
+		await Promise.allSettled(promises);
+	}
+
+	override close() {
+		if (this.mainCoder.state !== 'closed') this.mainCoder.close();
+		if (this.alphaCoder.state !== 'closed') this.alphaCoder.close();
+		this.closed = true;
+		delete this.canvas;
+	}
+
+	/** @internal */
+	_getAlphaOutputResolver(microsecondTimestamp: number) {
+		if (!this.alphaOutputResolverMap.has(microsecondTimestamp)) {
+			this.alphaOutputResolverMap.set(microsecondTimestamp, promiseWithResolvers());
+		}
+
+		const resolver = this.alphaOutputResolverMap.get(microsecondTimestamp)!;
+
+		if (this.mainCoderError || this.alphaCoderError || this.closed) {
+			resolver.resolve(null);
+		}
+
+		return resolver;
+	}
+
+	/** @internal */
+	async _extractAlpha(videoSample: VideoSample) {
+		const format = videoSample.format || '';
+		const alpha = format.includes('A')
+			|| videoSample.format === null; // Edge case: somehow null for HEVC with alpha at Chrome 139
+
+		if (!alpha || videoSample._closed || this.alphaCoderError) {
+			return null;
+		};
+
+		this.canvas ??= new OffscreenCanvas(videoSample.codedWidth, videoSample.codedHeight);
+
+		const ctx = this.canvas.getContext('2d');
+
+		assert(ctx);
+		ctx.globalCompositeOperation = 'copy';
+		ctx.drawImage(videoSample.toCanvasImageSource(), 0, 0);
+		ctx.globalCompositeOperation = 'source-in';
+		ctx.fillStyle = 'white';
+		ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+
+		return new VideoFrame(this.canvas, {
+			timestamp: videoSample.microsecondTimestamp,
+			duration: videoSample.microsecondDuration,
+			alpha: 'discard',
+		});
+	}
+}
+
+/**
+ * Registers the experimental custom decoder for handling supported packets with alpha channel in `VideoCodec` for WebM.
+ * By internally splitting input into 2 separate video track and 2 `VideoEncoder` to decode separately, then combine.
+ * Without this, alpha channel will be ignored since there is no native API to provide the alpha data currently.
+ * Then: `VideoEncoderConfig.alpha: 'keep'`.
+ *
+ * ```ts
+ * import { canEncode, registerWebMSeparateAlphaEncoder, type VideoEncoderConfig } from 'mediabunny';
+ *
+ * // 'av1', 'vp9', 'vp8'
+ * if (!canEncode('vp9', { alpha: 'keep' })) registerWebMSeparateAlphaEncoder();
+ *
+ * const config: VideoEncoderConfig = { ...others, alpha: 'keep' }; // default 'discard'
+ * ```
+ *
+ * @alpha
+ */
+export const registerWebMSeparateAlphaEncoder = () => registerEncoder(WebMSeparateAlphaEncoder);

--- a/src/webm-alpha.ts
+++ b/src/webm-alpha.ts
@@ -151,7 +151,7 @@ class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
 	// Should check if input actually has alpha instead of by 'prefer-software', but no access to _backing here
 	static override supports(codec: VideoCodec, config: VideoDecoderConfig) {
 		// Hardware accelerated have impractically worse performance in `copyTo` based implementation of _combineAlpha
-		return ['vp9', 'av1', 'vp8'].includes(codec)
+		return ['vp9', 'vp8'].includes(codec)
 			&& config.hardwareAcceleration === 'prefer-software'
 			&& typeof VideoDecoder !== 'undefined'
 			&& typeof VideoFrame !== 'undefined';
@@ -302,7 +302,7 @@ class WebMSeparateAlphaEncoder extends CustomVideoEncoder {
 	// Should check if output format supports also, but no access in CustomVideoEncoder
 	static override supports(codec: VideoCodec, config: VideoEncoderConfig) {
 		return config.alpha === 'keep'
-			&& ['vp9', 'av1', 'vp8'].includes(codec) // AV1 supports b-frame, but seems no browser implements that now
+			&& ['vp9', 'vp8'].includes(codec)
 			&& typeof VideoEncoder !== 'undefined'
 			&& typeof VideoFrame !== 'undefined';
 	}

--- a/src/webm-alpha.ts
+++ b/src/webm-alpha.ts
@@ -224,6 +224,8 @@ class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
 	override flush = () => this.coder.flush();
 }
 
+let _isWebMSeparateAlphaDecoderRegistered = false;
+
 /**
  * Registers the experimental custom decoder for handling supported packets with alpha channel in `VideoCodec` for WebM
  * By internally creating 2 `VideoDecoder` to handle main color data and additional data (alpha) separately and combine.
@@ -241,12 +243,19 @@ class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
  *
  * @alpha
  */
-export const registerWebMSeparateAlphaDecoder = () => registerDecoder(WebMSeparateAlphaDecoder);
+export const registerWebMSeparateAlphaDecoder = () => {
+	if (!_isWebMSeparateAlphaDecoderRegistered) {
+		_isWebMSeparateAlphaDecoderRegistered = true;
+		registerDecoder(WebMSeparateAlphaDecoder);
+	}
+};
 
-/** @internal */
-export const isWebMSeparateAlphaDecoderRegistered = () => customVideoDecoders.some(
-	decoder => decoder.name === 'WebMSeparateAlphaDecoder', // By name for tree shaking.
-);
+/**
+ * By a flag for tree shaking
+ *
+ * @internal
+ */
+export const isWebMSeparateAlphaDecoderRegistered = () => _isWebMSeparateAlphaDecoderRegistered;
 
 const extractAlpha = async (videoSample: VideoSample) => {
 	const format = videoSample.format || '';

--- a/src/webm-alpha.ts
+++ b/src/webm-alpha.ts
@@ -18,22 +18,27 @@ import { isSafari, promiseWithResolvers } from './misc';
 import { EncodedPacket } from './packet';
 import { VideoSample } from './sample';
 
-class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
-	private mainCoder!: VideoDecoder;
-	private alphaCoder!: VideoDecoder;
+type CoderType = VideoDecoder | VideoEncoder;
+type CoderOutput<T extends CoderType> = T extends VideoDecoder
+	? VideoFrame
+	: EncodedVideoChunk;
 
-	private mainCoderError: Error | null = null;
-	private alphaCoderError: Error | null = null;
+class Coder<T extends CoderType> {
+	mainCoder!: T;
+	alphaCoder!: T;
+
+	mainCoderError: Error | null = null;
+	alphaCoderError: Error | null = null;
 
 	// Main output needs to wait for alpha output to be ready, or null due to unexpected issue
-	private alphaOutputResolverMap = new Map<
+	alphaOutputResolverMap = new Map<
 		number,
-		ReturnType<typeof promiseWithResolvers<VideoFrame | null>>
+		ReturnType<typeof promiseWithResolvers<CoderOutput<T> | null>>
 	>();
 
-	private closed = false;
+	closed = false;
 
-	private setAlphaCoderError(error: Error) {
+	setAlphaCoderError(error: Error) {
 		if (this.alphaCoderError) {
 			return;
 		}
@@ -44,75 +49,6 @@ class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
 
 		this.alphaOutputResolverMap.clear();
 		this.alphaCoderError = error;
-	}
-
-	// Should check if input actually has alpha instead of by 'prefer-software', but no access to _backing here
-	static override supports(codec: VideoCodec, config: VideoDecoderConfig) {
-		// Hardware accelerated have impractically worse performance in `copyTo` based implementation of _combineAlpha
-		return ['vp9', 'av1', 'vp8'].includes(codec)
-			&& config.hardwareAcceleration === 'prefer-software'
-			&& typeof VideoDecoder !== 'undefined'
-			&& typeof VideoFrame !== 'undefined'
-			&& !isSafari(); // Safari v18.6: broken when creating I420A, I420 works with the same data buffer
-	}
-
-	override init() {
-		this.mainCoder = new VideoDecoder({
-			output: (output) => {
-				const resolver = this._getAlphaOutputResolver(output.timestamp);
-				(async () => {
-					let alpha;
-					let frame;
-
-					try {
-						alpha = await resolver.promise.catch(() => {});
-						frame = await this._combineAlpha(output, alpha);
-
-						this.onSample(new VideoSample(frame));
-					} finally {
-						if (frame !== output) output.close();
-						alpha?.close();
-					}
-				})().catch(() => {});
-			},
-
-			error: (error) => {
-				this.mainCoderError = error;
-				this.close();
-			},
-		});
-		this.mainCoder.configure(this.config);
-		this.alphaCoder = new VideoDecoder({
-			output: (output) => {
-				if (this.mainCoderError || this.alphaCoderError || this.closed) {
-					return output.close();
-				}
-
-				this._getAlphaOutputResolver(output.timestamp).resolve(output);
-			},
-			error: error => this.setAlphaCoderError(error),
-		});
-		this.alphaCoder.configure(this.config);
-	}
-
-	override decode(packet: EncodedPacket) {
-		const resolver = this._getAlphaOutputResolver(packet.microsecondTimestamp);
-
-		if (packet.additions) {
-			this.alphaCoder.decode(
-				new EncodedPacket(
-					packet.additions,
-					packet.type,
-					packet.timestamp,
-					packet.duration,
-					packet.sequenceNumber,
-				).toEncodedVideoChunk(),
-			);
-		} else {
-			resolver.resolve(null);
-		}
-
-		this.mainCoder.decode(packet.toEncodedVideoChunk());
 	}
 
 	async flush() {
@@ -130,15 +66,14 @@ class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
 		await Promise.allSettled(promises);
 	}
 
-	override close() {
+	close() {
 		if (this.mainCoder.state !== 'closed') this.mainCoder.close();
 		if (this.alphaCoder.state !== 'closed') this.alphaCoder.close();
 		this.closed = true;
 		this.alphaOutputResolverMap.clear();
 	}
 
-	/** @internal */
-	_getAlphaOutputResolver(microsecondTimestamp: number) {
+	getAlphaOutputResolver(microsecondTimestamp: number) {
 		if (!this.alphaOutputResolverMap.has(microsecondTimestamp)) {
 			this.alphaOutputResolverMap.set(microsecondTimestamp, promiseWithResolvers());
 		}
@@ -152,69 +87,141 @@ class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
 		return resolver;
 	}
 
-	/** @internal */
-	async _combineAlpha(main: VideoFrame, alpha?: VideoFrame | null | void) {
-		// No alpha, or closed
-		if (!alpha || alpha.displayWidth === 0) {
-			return main;
-		}
+	shouldIgnoreAlphaOutput() {
+		return this.mainCoderError || this.alphaCoderError || this.closed;
+	}
+}
 
-		const format = main.format || '';
-		const isYUV = format.startsWith('I');
-		const resultFormat = isYUV
-			? `${format.slice(0, 4)}A${format.slice(4, format.length)}` as VideoPixelFormat // e.g. I420AP12
-			: format.endsWith('X')
-				? `${format.slice(0, 3)}A` as VideoPixelFormat
-				: format;
+const combineAlpha = async (main: VideoFrame, alpha?: VideoFrame | null | void) => {
+	// No alpha, or closed
+	if (!alpha || alpha.displayWidth === 0) {
+		return main;
+	}
 
-		// Already has A, or NV12 (mainly from hardware accelerated cases)
-		if (!format || resultFormat === format) {
-			this.setAlphaCoderError(new Error(`Unsupported format: ${format}`));
+	const format = main.format || '';
+	const isYUV = format.startsWith('I');
+	const resultFormat = isYUV
+		? `${format.slice(0, 4)}A${format.slice(4, format.length)}` as VideoPixelFormat // e.g. I420AP12
+		: format.endsWith('X')
+			? `${format.slice(0, 3)}A` as VideoPixelFormat
+			: format;
 
-			return main;
-		};
+	// Already has A, or NV12 (mainly from hardware accelerated cases)
+	if (!format || resultFormat === format) {
+		return main;
+	};
 
-		try {
-			const mainSize = main.allocationSize();
-			const alphaSize = alpha.allocationSize();
-			const data = new Uint8Array(mainSize + alphaSize);
-			const alphaArray = data.subarray(mainSize, data.byteLength);
+	const mainSize = main.allocationSize();
+	const alphaSize = alpha.allocationSize();
+	const data = new Uint8Array(mainSize + alphaSize);
+	const alphaArray = data.subarray(mainSize, data.byteLength);
 
-			await Promise.all([
-				main.copyTo(data.subarray(0, mainSize)),
-				alpha.copyTo(alphaArray),
-			]);
+	await Promise.all([
+		main.copyTo(data.subarray(0, mainSize)),
+		alpha.copyTo(alphaArray),
+	]);
 
-			// YUV planar format are ready as-is.
-			// But for RGB formats, need to copy 1 channel to X channel.
-			// For alpha channel, UV are dummy
-			// Optimization: most implementation should give the same RGB values by filling UV with max value
-			// Otherwise need luminanceToAlpha, ref: https://www.w3.org/TR/SVG11/filters.html#feColorMatrixElement
-			// e.g. Chrome: I420, Firefox: BGRX.
-			if (!isYUV) {
-				for (let i = 0; i < alphaSize; i += 4) {
-					data[i + 3] = data[mainSize + i]!;
-				}
-			}
-
-			return new VideoFrame(data, {
-				codedWidth: main.displayWidth, // As a result of copyTo
-				codedHeight: main.displayHeight,
-				displayWidth: main.displayWidth,
-				displayHeight: main.displayHeight,
-				colorSpace: main.colorSpace,
-				timestamp: main.timestamp,
-				duration: main.duration ?? undefined,
-				format: resultFormat,
-				transfer: [data.buffer],
-			} as VideoFrameBufferInit);
-		} catch (error) {
-			/** @ts-expect-error ECMAScript target */
-			this.setAlphaCoderError(new Error('Combine alpha failed', { cause: error }));
-
-			return main;
+	// YUV planar format are ready as-is.
+	// But for RGB formats, need to copy 1 channel to X channel.
+	// For alpha channel, UV are dummy
+	// Optimization: most implementation should give the same RGB values by filling UV with max value
+	// Otherwise need luminanceToAlpha, ref: https://www.w3.org/TR/SVG11/filters.html#feColorMatrixElement
+	// e.g. Chrome: I420, Firefox: BGRX.
+	if (!isYUV) {
+		for (let i = 0; i < alphaSize; i += 4) {
+			data[i + 3] = data[mainSize + i]!;
 		}
 	}
+
+	return new VideoFrame(data, {
+		codedWidth: main.displayWidth, // As a result of copyTo
+		codedHeight: main.displayHeight,
+		displayWidth: main.displayWidth,
+		displayHeight: main.displayHeight,
+		colorSpace: main.colorSpace,
+		timestamp: main.timestamp,
+		duration: main.duration ?? undefined,
+		format: resultFormat,
+		transfer: [data.buffer],
+	} as VideoFrameBufferInit);
+};
+
+class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
+	coder = new Coder<VideoDecoder>();
+
+	// Should check if input actually has alpha instead of by 'prefer-software', but no access to _backing here
+	static override supports(codec: VideoCodec, config: VideoDecoderConfig) {
+		// Hardware accelerated have impractically worse performance in `copyTo` based implementation of _combineAlpha
+		return ['vp9', 'av1', 'vp8'].includes(codec)
+			&& config.hardwareAcceleration === 'prefer-software'
+			&& typeof VideoDecoder !== 'undefined'
+			&& typeof VideoFrame !== 'undefined'
+			&& !isSafari(); // Safari v18.6: broken when creating I420A, I420 works with the same data buffer
+	}
+
+	override init() {
+		this.coder.mainCoder = new VideoDecoder({
+			output: (output) => {
+				const resolver = this.coder.getAlphaOutputResolver(output.timestamp);
+
+				(async () => {
+					let alpha;
+					let frame;
+
+					try {
+						alpha = await resolver.promise.catch(() => {});
+						frame = await combineAlpha(output, alpha).catch(() => {
+							this.coder.setAlphaCoderError(new Error('Failed to combine alpha'));
+							return output;
+						});
+						this.onSample(new VideoSample(frame));
+					} finally {
+						if (frame !== output) output.close();
+						alpha?.close();
+					}
+				})().catch(() => {});
+			},
+			error: (error) => {
+				this.coder.mainCoderError = error;
+				this.close();
+			},
+		});
+		this.coder.mainCoder.configure(this.config);
+		this.coder.alphaCoder = new VideoDecoder({
+			output: (output) => {
+				if (this.coder.shouldIgnoreAlphaOutput()) {
+					return output.close();
+				}
+
+				this.coder.getAlphaOutputResolver(output.timestamp).resolve(output);
+			},
+			error: error => this.coder.setAlphaCoderError(error),
+		});
+		this.coder.alphaCoder.configure(this.config);
+	}
+
+	override decode(packet: EncodedPacket) {
+		const resolver = this.coder.getAlphaOutputResolver(packet.microsecondTimestamp);
+
+		if (packet.additions) {
+			this.coder.alphaCoder.decode(
+				new EncodedPacket(
+					packet.additions,
+					packet.type,
+					packet.timestamp,
+					packet.duration,
+					packet.sequenceNumber,
+				).toEncodedVideoChunk(),
+			);
+		} else {
+			resolver.resolve(null);
+		}
+
+		this.coder.mainCoder.decode(packet.toEncodedVideoChunk());
+	}
+
+	override close = () => this.coder.close();
+	override flush = () => this.coder.flush();
 }
 
 /**
@@ -239,33 +246,50 @@ export const registerWebMSeparateAlphaDecoder = () => registerDecoder(WebMSepara
 /** @internal */
 export const isWebMSeparateAlphaDecoderRegistered = () => customVideoDecoders.includes(WebMSeparateAlphaDecoder);
 
-class WebMSeparateAlphaEncoder extends CustomVideoEncoder {
-	private mainCoder!: VideoEncoder;
-	private alphaCoder!: VideoEncoder;
+const extractAlpha = async (videoSample: VideoSample) => {
+	const format = videoSample.format || '';
 
-	private mainCoderError: Error | null = null;
-	private alphaCoderError: Error | null = null;
+	if (
+		!format.includes('A') // Chrome v139: HEVC with alpha might give null, but cannot copyTo anyway
+		|| videoSample._closed
+		|| format.length > 5 // Not handling cases like I444AP12, not possible in browser now, will become null
+	) {
+		return null;
+	};
 
-	// Main output needs to wait for alpha output to be ready, or null due to unexpected issue
-	private alphaOutputResolverMap = new Map<
-		number,
-		ReturnType<typeof promiseWithResolvers<EncodedVideoChunk | null>>
-	>();
+	// RGB formats (like canvas) will get converted to 16-255 in browsers, and give broken result
+	const isYUV = format.startsWith('I') || format.startsWith('N');
+	const finalFormat = isYUV ? format.slice(0, 4) : 'I420';
+	const size = videoSample.allocationSize();
+	const data = new Uint8Array(size);
+	const pixels = videoSample.codedWidth * videoSample.codedHeight;
 
-	private closed = false;
+	await videoSample.copyTo(data);
 
-	private setAlphaCoderError(error: Error) {
-		if (this.alphaCoderError) {
-			return;
+	if (isYUV) {
+		data.set(data.subarray(size - pixels, size));
+	} else {
+		for (let i = 0; i < pixels; i++) {
+			data[i] = data[i * 4 + 3]!;
 		}
-
-		for (const resolver of this.alphaOutputResolverMap.values()) {
-			resolver.resolve(null);
-		}
-
-		this.alphaOutputResolverMap.clear();
-		this.alphaCoderError = error;
 	}
+
+	// eslint-disable-next-line @stylistic/max-len
+	// More expensive to encode otherwise, according to https://source.chromium.org/chromium/chromium/src/+/main:media/video/alpha_video_encoder_wrapper.cc;l=117
+	data.fill(255, pixels, data.byteLength);
+
+	return new VideoFrame(data, {
+		timestamp: videoSample.microsecondTimestamp,
+		duration: videoSample.microsecondDuration,
+		format: finalFormat,
+		codedWidth: videoSample.codedWidth,
+		codedHeight: videoSample.codedHeight,
+		transfer: [data.buffer],
+	} as VideoFrameBufferInit);
+};
+
+class WebMSeparateAlphaEncoder extends CustomVideoEncoder {
+	coder = new Coder<VideoEncoder>();
 
 	// Should check if output format supports also, but no access in CustomVideoEncoder
 	static override supports(codec: VideoCodec, config: VideoEncoderConfig) {
@@ -282,9 +306,9 @@ class WebMSeparateAlphaEncoder extends CustomVideoEncoder {
 			alpha: 'discard',
 		};
 
-		this.mainCoder = new VideoEncoder({
+		this.coder.mainCoder = new VideoEncoder({
 			output: (chunk, metadata) => {
-				const resolver = this._getAlphaOutputResolver(chunk.timestamp);
+				const resolver = this.coder.getAlphaOutputResolver(chunk.timestamp);
 				const packet = EncodedPacket.fromEncodedChunk(chunk);
 
 				(async () => {
@@ -300,128 +324,52 @@ class WebMSeparateAlphaEncoder extends CustomVideoEncoder {
 				})().catch(() => {});
 			},
 			error: (error) => {
-				this.mainCoderError = error;
+				this.coder.mainCoderError = error;
 				this.close();
 			},
 		});
-		this.mainCoder.configure(config);
+		this.coder.mainCoder.configure(config);
 
 		// Better add when there is really data and properly check configure in supports first
 		// Need refactoring of current API
-		this.alphaCoder = new VideoEncoder({
+		this.coder.alphaCoder = new VideoEncoder({
 			output: (chunk) => {
-				if (this.mainCoderError || this.alphaCoderError || this.closed) {
+				if (this.coder.shouldIgnoreAlphaOutput()) {
 					return;
 				}
-
-				this._getAlphaOutputResolver(chunk.timestamp).resolve(chunk);
+				this.coder.getAlphaOutputResolver(chunk.timestamp).resolve(chunk);
 			},
-			error: error => this.setAlphaCoderError(error),
+			error: error => this.coder.setAlphaCoderError(error),
 		});
-		this.alphaCoder.configure(config);
+		this.coder.alphaCoder.configure(config);
 	}
 
 	override async encode(videoSample: VideoSample, options: VideoEncoderEncodeOptions) {
-		if (this.mainCoderError) {
+		if (this.coder.mainCoderError) {
 			/** @ts-expect-error ECMAScript target */
-			throw new Error('Cannot encode on a closed VideoEncoder', { cause: this.mainCoderError });
+			throw new Error('Cannot encode on a closed VideoEncoder', { cause: this.coder.mainCoderError });
 		}
 
-		const alpha = await this._extractAlpha(videoSample);
+		const resolver = this.coder.getAlphaOutputResolver(videoSample.microsecondTimestamp);
+		const alpha = await extractAlpha(videoSample).catch(() => {
+			this.coder.setAlphaCoderError(new Error('Failed to extractAlpha'));
+		});
 
 		if (alpha) {
-			this.alphaCoder.encode(alpha, options);
+			this.coder.alphaCoder.encode(alpha, options);
 			alpha.close();
 		} else {
-			this._getAlphaOutputResolver(videoSample.microsecondTimestamp).resolve(null);
+			resolver.resolve(null);
 		}
 
 		const frame = videoSample.toVideoFrame();
 
-		this.mainCoder.encode(frame, options);
+		this.coder.mainCoder.encode(frame, options);
 		frame.close();
 	}
 
-	async flush() {
-		await Promise.all([
-			this.mainCoder.flush(),
-			this.alphaCoder.flush(),
-		]);
-
-		const promises = [];
-
-		for (const resolver of this.alphaOutputResolverMap.values()) {
-			promises.push(resolver.promise);
-		}
-
-		await Promise.allSettled(promises);
-	}
-
-	override close() {
-		if (this.mainCoder.state !== 'closed') this.mainCoder.close();
-		if (this.alphaCoder.state !== 'closed') this.alphaCoder.close();
-		this.closed = true;
-		this.alphaOutputResolverMap.clear();
-	}
-
-	/** @internal */
-	_getAlphaOutputResolver(microsecondTimestamp: number) {
-		if (!this.alphaOutputResolverMap.has(microsecondTimestamp)) {
-			this.alphaOutputResolverMap.set(microsecondTimestamp, promiseWithResolvers());
-		}
-
-		const resolver = this.alphaOutputResolverMap.get(microsecondTimestamp)!;
-
-		if (this.mainCoderError || this.alphaCoderError || this.closed) {
-			resolver.resolve(null);
-		}
-
-		return resolver;
-	}
-
-	/** @internal */
-	async _extractAlpha(videoSample: VideoSample) {
-		const format = videoSample.format || '';
-
-		if (
-			!format.includes('A') // Chrome v139: HEVC with alpha might give null, but cannot copyTo anyway
-			|| videoSample._closed
-			|| this.alphaCoderError
-			|| format.length > 5 // Not handling cases like I444AP12, not possible in browser now, will become null
-		) {
-			return null;
-		};
-
-		// RGB formats (like canvas) will get converted to 16-255 in browsers, and give broken result
-		const isYUV = format.startsWith('I') || format.startsWith('N');
-		const finalFormat = isYUV ? format.slice(0, 4) : 'I420';
-		const size = videoSample.allocationSize();
-		const data = new Uint8Array(size);
-		const pixels = videoSample.codedWidth * videoSample.codedHeight;
-
-		await videoSample.copyTo(data);
-
-		if (isYUV) {
-			data.set(data.subarray(size - pixels, size));
-		} else {
-			for (let i = 0; i < pixels; i++) {
-				data[i] = data[i * 4 + 3]!;
-			}
-		}
-
-		// eslint-disable-next-line @stylistic/max-len
-		// More expensive to encode otherwise, according to https://source.chromium.org/chromium/chromium/src/+/main:media/video/alpha_video_encoder_wrapper.cc;l=117
-		data.fill(255, pixels, data.byteLength);
-
-		return new VideoFrame(data, {
-			timestamp: videoSample.microsecondTimestamp,
-			duration: videoSample.microsecondDuration,
-			format: finalFormat,
-			codedWidth: videoSample.codedWidth,
-			codedHeight: videoSample.codedHeight,
-			transfer: [data.buffer],
-		} as VideoFrameBufferInit);
-	}
+	override close = () => this.coder.close();
+	override flush = () => this.coder.flush();
 }
 
 /**

--- a/src/webm-alpha.ts
+++ b/src/webm-alpha.ts
@@ -81,7 +81,7 @@ class Coder<T extends CoderType> {
 
 		const resolver = this.alphaOutputResolverMap.get(microsecondTimestamp)!;
 
-		if (this.alphaCoderError || closed) {
+		if (this.alphaCoderError || this.closed) {
 			resolver.resolve(null);
 		}
 

--- a/src/webm-alpha.ts
+++ b/src/webm-alpha.ts
@@ -9,7 +9,6 @@
 import { VideoCodec } from './codec';
 import {
 	CustomVideoDecoder,
-	customVideoDecoders,
 	CustomVideoEncoder,
 	registerDecoder,
 	registerEncoder,

--- a/src/webm-alpha.ts
+++ b/src/webm-alpha.ts
@@ -243,7 +243,9 @@ class WebMSeparateAlphaDecoder extends CustomVideoDecoder {
 export const registerWebMSeparateAlphaDecoder = () => registerDecoder(WebMSeparateAlphaDecoder);
 
 /** @internal */
-export const isWebMSeparateAlphaDecoderRegistered = () => customVideoDecoders.includes(WebMSeparateAlphaDecoder);
+export const isWebMSeparateAlphaDecoderRegistered = () => customVideoDecoders.some(
+	decoder => decoder.name === 'WebMSeparateAlphaDecoder', // By name for tree shaking.
+);
 
 const extractAlpha = async (videoSample: VideoSample) => {
 	const format = videoSample.format || '';


### PR DESCRIPTION
Should suffice for: https://github.com/Vanilagy/mediabunny/issues/55.
WebM alpha works by adding additional data, which is another encoded stream. [Implementation ref](https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libvpxdec.c)

Only support for VP8/VP9 for encoding.
VP8/VP9/AV1 for decoding.
AV1 with alpha in WebM seems uncommon that no browser support playback with alpha natively. However, the basically same logic for AV1 case, [alpha support with AVIF is common](https://aomediacodec.github.io/av1-avif/#av1-alpha-image-item).

Note: Chrome support WebM with VP8/VP9 alpha encoding natively with MediaRecorder. [WebRTC Sample](https://webrtc.github.io/samples/src/content/capture/canvas-record/)

Changes:
- [x] 1. Minor additions to matroska-demuxer and matroska-muxer
- [x] 2. Custom alpha decoder + combining.
    - [x] Demuxer detect feature need, (probably better to do at `CustomVideoEncoder.supports`, but no access to packet now)
    - [ ] (*) Scope limitation: software decoding only
- [x] 3. Custom alpha encoder + extracting.
    - [x] Fix alpha has limited range
    - [ ] (*) Main library refactor needed: detect feature need based on output format instead of always override default behaviour when custom encoder registered.
- [x] 4. Handle YUV planar format.
- [x] 5. Handle RGB format, from `canvas` / Firefox's `VideoDecoder` result.
    - [ ] (*) Limitation: per pixel manipulation, inefficient compare to YUV planar.
    - [ ] (*) Limitation on transcoding: Chrome's `VideoDecoder` gives `VideoFrame.format: null` for HEVC with alpha. Might be possible to handle by `copyTo` BGRX formats. But [`VideoFrameCopyToOptions`](https://www.w3.org/TR/webcodecs/#videoframe-copyto-options) is not supported in `VideoSample` now. But can hope that Chrome fixes it on their side. [Example HEVC with alpha file](https://jakearchibald.com/c/hevc-D_-LfvxD.mov).
- [x] 6. Add alpha handling for internal canvas usage.
- [x] 7. Check and resolve irregularity for Chrome, Firefox, Safari.
- [x] 8. Check if encoded webm works in `MediaSource`: [Chromium needs `BlockAddID` to come first](https://source.chromium.org/chromium/chromium/src/+/main:media/formats/webm/webm_cluster_parser.cc;l=404;drc=48d6f7175422b2c969c14258f9f8d5b196c28d18;bpv=1;bpt=1) when used in MSE.

Technically, only 1. is needed in the library for user to implement their custom support (without forking).
I see that a "basic" support could be useful for many so I created the PR. But it is totally fine to close this if there are other plans (or if the code is an abomination).

IMPORTANT NOTE on 3.: `VideoFrame` with RGB formats like `canvas` would get clamped to `16-255` range internally in browser `VideoEncoder` probably due to conversion to `'I420'` but a full range `'J420'` is needed for alpha channel. While browser does not break manually created `'I420'` `Videoframe` now, this whole manual separate alpha in JS implementation idea relies on this piece of browser implementation detail to work.

Note:
HEVC with alpha decoding already works as-is, but internal `canvas` usage presumes always opaque (fixed with 6.).

Not in scope:
(*) Items are out of scope due to main library impacts/significant extra complexity while not required for the feature.
- [x] 1. Investigate on Firefox slow VP9 encoding (generally). https://github.com/Vanilagy/mediabunny/issues/102#issuecomment-3265573488
- [ ] 2. Encode AV1 with alpha. Descoped, no native decoding support in any browser.
- [ ] 3. Optimization: `copyTo` from hardware backed `VideoFrame` by [async readback](https://issuetracker.google.com/issues/340606792). e.g. `encode` for `CanvasSource` can be faster by parallel readback instead of simply `await extractAlpha`.
- [ ] 4. Should we split the `bitrate` to maybe main 3 : 1 alpha ratio? Seems not performed in `FFmpeg` but quite wasteful without for `bitrateMode: 'constant'`.