### PR TITLE
Add dynamic video URL support for Media Player

### DIFF
--- a/examples/media-player/media-player.ts
+++ b/examples/media-player/media-player.ts
@@ -694,3 +694,12 @@ document.addEventListener('drop', (event) => {
 		void initMediaPlayer(file);
 	}
 });
+
+document.addEventListener("DOMContentLoaded", () => {
+	const urlParams = new URLSearchParams(window.location.search);
+	const url = urlParams.get("video_url");
+
+	if (url) {
+		void initMediaPlayer(url);
+	}
+});


### PR DESCRIPTION
This update allows the MediaBunny player to load videos dynamically via a URL query parameter. Users can now pass a `video_url` in the page URL to load any video without modifying the code.

Makes it easier for demo video.

**Usage Example:**

```
https://mediabunny.dev/examples/media-player/?video_url=https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
```