### PR TITLE
Multiple inputs support for Conversion

### DIFF
--- a/docs/guide/converting-media-files.md
+++ b/docs/guide/converting-media-files.md
@@ -45,7 +45,25 @@ await conversion.execute();
 // output.target.buffer contains the final file
 ```
 
-That's it! A `Conversion` simply takes an instance of `Input` and `Output`, then reads the data from the input and writes it to the output. If you're unfamiliar with [`Input`](./reading-media-files) and [`Output`](./writing-media-files), check out their respective guides.
+Additionally, it is possible to pass multiple `Input`'s in `input` field as array:
+```
+// ...
+
+const inputA = new Input({ ... });
+const inputB = new Input({ ... });
+const output = new Output({
+	format: new WebMOutputFormat(),
+	target: new BufferTarget(),
+});
+// This may be useful in case when audio and video streams are stored in separated files
+
+const conversion = await Conversion.init({ input: [ inputA, inputB ], output: output });
+await conversion.execute();
+```
+
+When multiple inputs are used they duration must be equal. Also, if inputs contain metadata, only the metadata from the first provided input will be used in the output.
+
+That's it! A `Conversion` simply takes an instance(s) of `Input` and `Output`, then reads the data from the input and writes it to the output. If you're unfamiliar with [`Input`](./reading-media-files) and [`Output`](./writing-media-files), check out their respective guides.
 
 ::: info
 The `Output` passed to the `Conversion` must be *fresh*; that is, it must have no added tracks and be in the `'pending'` state (not started yet).

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -374,8 +374,10 @@ export class Conversion {
 		}
 		if (!(options.input instanceof Input) &&
 			!(Array.isArray(options.input) &&
-				(options.input.length > 0) &&
-				options.input.every((input) => { return (input instanceof Input); })))
+				((options.input as Array<Input>).length > 0) &&
+				(options.input as Array<Input>).every((input) => {
+					return (input instanceof Input);
+				})))
 		{
 			throw new TypeError('options.input must be an Input or non-empty Input[].');
 		}
@@ -433,10 +435,10 @@ export class Conversion {
 	async _init() {
 		if (this.inputs.length > 1) {
 			let durationMatch = true;
-			const baseDuration = Math.ceil(await this.inputs[0].computeDuration());
+			const baseDuration = Math.ceil(await this.inputs[0]!.computeDuration());
 			for (const input of this.inputs) {
 				const inputDuration = Math.ceil(await input.computeDuration());
-				durationMatch &= (inputDuration == baseDuration);
+				durationMatch &&= (inputDuration == baseDuration);
 			}
 			if (!durationMatch) {
 				throw new Error('inputs duration does not match.');
@@ -514,7 +516,7 @@ export class Conversion {
 
 		// Now, let's deal with metadata tags
 
-		const inputTags = await this.inputs[0].getMetadataTags();
+		const inputTags = await this.inputs[0]!.getMetadataTags();
 		let outputTags: MetadataTags;
 
 		if (this._options.tags) {
@@ -528,7 +530,7 @@ export class Conversion {
 
 		// Somewhat dirty but pragmatic
 		const inputAndOutputFormatMatch = (this.inputs.length == 1) &&
-			((await this.inputs[0].getFormat()).mimeType === this.output.format.mimeType);
+			((await this.inputs[0]!.getFormat()).mimeType === this.output.format.mimeType);
 		const rawTagsAreUnchanged = inputTags.raw === outputTags.raw;
 
 		if (inputTags.raw && rawTagsAreUnchanged && !inputAndOutputFormatMatch) {
@@ -562,7 +564,7 @@ export class Conversion {
 		if (this.onProgress) {
 			this._computeProgress = true;
 			this._totalDuration = Math.min(
-				(await this.inputs[0].computeDuration()) - this._startTimestamp,
+				(await this.inputs[0]!.computeDuration()) - this._startTimestamp,
 				this._endTimestamp - this._startTimestamp,
 			);
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -548,6 +548,11 @@ export class FilePathSource extends Source {
 		// Let's back this source with a StreamSource, makes the implementation very simple
 		this._streamSource = new StreamSource({
 			getSize: async () => {
+				if (process.env.IS_ELECTRON) {
+					console.error('fixme: file size query is not implemented for Electron.')
+					return 0;
+				}
+
 				const FS_MODULE_NAME = 'node:fs/promises';
 				const fs = await import(/* @vite-ignore */ FS_MODULE_NAME) as typeof import('node:fs/promises');
 				fileHandle = await fs.open(filePath, 'r');

--- a/src/source.ts
+++ b/src/source.ts
@@ -548,7 +548,7 @@ export class FilePathSource extends Source {
 		// Let's back this source with a StreamSource, makes the implementation very simple
 		this._streamSource = new StreamSource({
 			getSize: async () => {
-				if (process.env.IS_ELECTRON) {
+				if (process.env['IS_ELECTRON']) {
 					console.error('fixme: file size query is not implemented for Electron.')
 					return 0;
 				}


### PR DESCRIPTION
I propose to add functionality to handle multiple inputs in Conversion. This feature may be useful when there are need to mux audio and video streams which are stored each in separate files. I'm trying to make use of mediabunny in FreeTube project to download and mux audio and video streams to single file. I've tested tweaked version of mediabunny with my changes and it works very well.

There are another unrelated change in this pull request: I noticed that when used with Electron the mediabunny is unable to load because of unreachable node fs module, requested in source.ts to query file size. I added a fix for this, a simple stub that checks if it is running under Electron and then avoids access to fs. This fix is far from ideal, but without it the whole library refuses to load.