### PR TITLE
Fix WAV files with embedded ID3 metadata returning empty tags

### DIFF
--- a/src/mp3/mp3-reader.ts
+++ b/src/mp3/mp3-reader.ts
@@ -586,7 +586,7 @@ export class Id3V2Reader {
 
 	readId3V2Text(encoding: Id3V2TextEncoding, until: number): string {
 		const startPos = this.pos;
-		const data = this.readBytes(until);
+		const data = this.readBytes(until - this.pos);
 
 		switch (encoding) {
 			case Id3V2TextEncoding.ISO_8859_1: {

--- a/test/node/metadata-tags.test.ts
+++ b/test/node/metadata-tags.test.ts
@@ -481,3 +481,43 @@ test('Conversion metadata tags, modified', async () => {
 	expect(readTags.artist).toBe(songMetadata.artist);
 	expect(Object.keys(readTags.raw!).length).toBe(2);
 });
+
+test('Read ID3v2 tags from WAV file', async () => {
+	const filePath = path.join(import.meta.dirname, '../public/glitch-hop-is-dead.wav');
+
+	const input = new Input({
+		source: new FilePathSource(filePath),
+		formats: ALL_FORMATS,
+	});
+
+	const tags = await input.getMetadataTags();
+
+	// Specific expectations for the test WAV file
+	expect(tags.title).toBe('Glitch Hop Is Dead');
+	expect(tags.artist).toBe('GRiZ');
+	expect(tags.trackNumber).toBe(19);
+
+	if (!tags.images) {
+		throw new Error('No images found in the file');
+	}
+
+	const frontCover = tags.images[0];
+
+	if (!frontCover) {
+		throw new Error('No front cover found in the file');
+	}
+
+	expect(frontCover.kind).toBe('coverFront');
+	expect(frontCover.mimeType).toBe('image/jpg');
+	expect(frontCover.data).toBeInstanceOf(Uint8Array);
+	expect(frontCover.data.length).toBeGreaterThan(0);
+
+	if (!tags.raw) {
+		throw new Error('No raw tags found in the file');
+	}
+
+	expect(tags.raw['TIT2']).toBeDefined(); // Title
+	expect(tags.raw['TPE1']).toBeDefined(); // Artist
+	expect(tags.raw['TRCK']).toBeDefined(); // Track number
+	expect(tags.raw['APIC']).toBeDefined(); // Cover art
+});


### PR DESCRIPTION


**Background:** I downloaded a legitimate music release (free download) that had WAV files with ID3 tags. These files work fine everywhere else:

- macOS shows artwork and metadata in Finder
- DJ software like rekordbox and Engine DJ reads them properly
- Tag editors like Music Tag Editor work with them

But Mediabunny was returning `{}` for these files.

Turns out ID3 in WAV files isn't officially part of the WAV spec, but it's become really common in practice. 

From what I read in ChatGPT:

> "Many taggers and apps put a full ID3v2 tag inside a RIFF chunk... People do it because ID3v2 is convenient and widely supported by tag editors — tools like Mp3tag, foobar2000 and various rippers will write ID3 metadata to WAVs. That makes WAVs easier to tag in workflows that expect ID3."

So the files I had were using this de-facto standard - proper ID3v2 tags embedded as RIFF chunks

## The debugging process

1. First issue: WAV files returned empty metadata
2. I tried reusing the existing readId3V2Header() logic
3. That worked partially, but now text fields were corrupted like "Glitch Hop Is DeadTPE1" instead of just "Glitch Hop Is Dead"
4. Claude helped me trace this to a bug in the core ID3v2 frame parsing

### AI explanation of the bug with frame parsing

**The actual bug:** In `src/mp3/mp3-reader.ts` there was a line that passed a position value where it should pass a length:
```ts
// Wrong - this reads way too much data
const data = this.readBytes(until);

// Fixed - calculate the actual length needed
const data = this.readBytes(until - this.pos);
```

This was causing frame boundary violations where text parsing would read into the next frame's header.

## What got fixed

```ts
// Before
await input.getMetadataTags(); // {}

// After
await input.getMetadataTags();
// { title: "Glitch Hop Is Dead", artist: "GRiZ", trackNumber: 19,
images: [...] }
```


## Summary

- WAV files with ID3 chunks now parse correctly ✅
- The underlying frame boundary bug got fixed for all formats ✅
- Added proper test coverage with a real WAV file ✅ 
- All existing tests still pass ✅
