### PR TITLE
Enable headless mode for browser tests

### DIFF
--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		browser: {
 			provider: 'webdriverio',
 			instances: [{ browser: 'chrome' }],
+			headless: true,
 		},
 	},
 });


### PR DESCRIPTION
It has been bothering me, but a Chrome window would pop up, flash and then close whenever you run tests.
This runs the tests invisibly instead and doesn't distract you while coding.