### PR TITLE
Improve discarded tracks error message when trying to convert to MP3

### DIFF
--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -521,7 +521,18 @@ export class Conversion {
 		const unintentionallyDiscardedTracks = this.discardedTracks.filter(x => x.reason !== 'discarded_by_user');
 		if (unintentionallyDiscardedTracks.length > 0) {
 			// Let's give the user a notice/warning about discarded tracks so they aren't confused
-			console.warn('Some tracks had to be discarded from the conversion:', unintentionallyDiscardedTracks);
+			const mp3EncoderIssue = unintentionallyDiscardedTracks.some(t =>
+				t.reason === 'no_encodable_target_codec'
+				&& t.track.type === 'audio'
+				&& this.output.format.getSupportedAudioCodecs().includes('mp3'),
+			);
+
+			const message = mp3EncoderIssue
+				? `Some tracks had to be discarded from the conversion. If you're trying to encode MP3, 
+				consider installing @mediabunny/mp3-encoder (https://mediabunny.dev/guide/extensions/mp3-encoder):`
+				: 'Some tracks had to be discarded from the conversion:';
+
+			console.warn(message, unintentionallyDiscardedTracks);
 		}
 
 		// Now, let's deal with metadata tags


### PR DESCRIPTION
It took me around 20 minutes to remember that there's a WASM MP3 encoder by Mediabunny.

A better error message would’ve saved me some time 😃

@Vanilagy feel free to modify the approach - I’ve added an explicit check for MP3 since the encoder is only available as an installable module for now.