### PR TITLE
add maximumFragmentDuration to IsobmffOutputFormatOptions

### DIFF
--- a/docs/guide/output-formats.md
+++ b/docs/guide/output-formats.md
@@ -64,6 +64,7 @@ The following options are available:
 type IsobmffOutputFormatOptions = {
 	fastStart?: false | 'in-memory' | 'reserve' | 'fragmented';
 	minimumFragmentDuration?: number;
+	maximumFragmentDuration?: number;
 	metadataFormat?: 'mdir' | 'mdta' | 'udta' | 'auto';
 
 	onFtyp?: (data: Uint8Array, position: number) => unknown;
@@ -95,6 +96,8 @@ type IsobmffOutputFormatOptions = {
 		The default option; it behaves like `'in-memory'` when using [`BufferTarget`](./writing-media-files#buffertarget) and like `false` otherwise.
 - `minimumFragmentDuration`\
 	Only relevant when `fastStart` is `'fragmented'`. Sets the minimum duration in seconds a fragment must have to be finalized and written to the file. Defaults to 1 second.
+- `maximumFragmentDuration`\
+	Only relevant when `fastStart` is `'fragmented'`. Sets the maximum duration in seconds a fragment can have before it must be finalized and written to the file. Must be greater than or equal to `minimumFragmentDuration` when both are set.
 - `metadataFormat`\
 	The metadata format to use for writing metadata tags.
 	- `'auto'` (default): Behaves like `'mdir'` for MP4 and like `'udta'` for QuickTime, matching FFmpeg's default behavior.

--- a/src/output-format.ts
+++ b/src/output-format.ts
@@ -141,6 +141,12 @@ export type IsobmffOutputFormatOptions = {
 	minimumFragmentDuration?: number;
 
 	/**
+	 * When using `fastStart: 'fragmented'`, this field controls the maximum duration of each fragment, in seconds.
+	 * When set, fragments will be finalized as soon as they exceed this duration.
+	 */
+	maximumFragmentDuration?: number;
+
+	/**
 	 * The metadata format to use for writing metadata tags.
 	 *
 	 * - `'auto'` (default): Behaves like `'mdir'` for MP4 and like `'udta'` for QuickTime, matching FFmpeg's default
@@ -215,6 +221,22 @@ export abstract class IsobmffOutputFormat extends OutputFormat {
 			&& (!Number.isFinite(options.minimumFragmentDuration) || options.minimumFragmentDuration < 0)
 		) {
 			throw new TypeError('options.minimumFragmentDuration, when provided, must be a non-negative number.');
+		}
+		if (
+			options.maximumFragmentDuration !== undefined
+			&& (!Number.isFinite(options.maximumFragmentDuration) || options.maximumFragmentDuration < 0)
+		) {
+			throw new TypeError('options.maximumFragmentDuration, when provided, must be a non-negative number.');
+		}
+		if (
+			options.minimumFragmentDuration !== undefined
+			&& options.maximumFragmentDuration !== undefined
+			&& options.maximumFragmentDuration < options.minimumFragmentDuration
+		) {
+			throw new TypeError(
+				'options.maximumFragmentDuration, when provided, must be greater than or equal to'
+				+ ' options.minimumFragmentDuration.',
+			);
 		}
 		if (options.onFtyp !== undefined && typeof options.onFtyp !== 'function') {
 			throw new TypeError('options.onFtyp, when provided, must be a function.');


### PR DESCRIPTION
Adds `maximumFragmentDuration` to the `IsobmffOutputFormatOptions`. When used in conjunction with `minimumFragmentDuration`, it allows specifying a a range (e.g. 2-5 seconds) or a specific fragment duration (e.g. 1 second)

This addresses https://github.com/Vanilagy/mediabunny/issues/159