### PR TITLE
add keyFrameInterval to ConversionVideoOptions

### DIFF
--- a/docs/guide/converting-media-files.md
+++ b/docs/guide/converting-media-files.md
@@ -124,6 +124,7 @@ type ConversionVideoOptions = {
 	codec?: VideoCodec;
 	bitrate?: number | Quality;
 	alpha?: 'discard' | 'keep'; // Defaults to 'discard'
+	keyFrameInterval?: number;
 	forceTranscode?: boolean;
 };
 ```
@@ -180,7 +181,9 @@ Use the `codec` property to control the codec of the output track. This should b
 
 Use the `bitrate` property to control the bitrate of the output video. For example, you can use this field to compress the video track. Accepted values are the number of bits per second or a [subjective quality](./media-sources#subjective-qualities). If this property is set, transcoding will always happen. If this property is not set but transcoding is still required, `QUALITY_HIGH` will be used as the value.
 
-If you want to prevent direct copying of media data and force a transcoding step, use `forceTranscode: true`.
+Use the `keyFrameInterval` property to control the interval in seconds between key frames in the output video.
+
+If you want to prevent direct copying of media data and force a transcoding step, use `forceTranscode: true`. Setting `keyFrameInterval` or `frameRate` will automatically force transcoding, even if `forceTranscode` is not explicitly set to `true`.
 
 ## Audio options
 


### PR DESCRIPTION
adds `keyFrameInterval` to `ConversionVideoOptions` to address https://github.com/Vanilagy/mediabunny/issues/103 and https://github.com/Vanilagy/mediabunny/issues/159