### PR TITLE
Fix the transfer characteristics map key for BT.2100 PQ

### DIFF
--- a/src/misc.ts
+++ b/src/misc.ts
@@ -208,7 +208,7 @@ export const TRANSFER_CHARACTERISTICS_MAP = {
 	'smpte170m': 6, // SMPTE 170M
 	'linear': 8, // Linear transfer characteristics
 	'iec61966-2-1': 13, // IEC 61966-2-1
-	'pg': 16, // Rec. ITU-R BT.2100-2 perceptual quantization (PQ) system
+	'pq': 16, // Rec. ITU-R BT.2100-2 perceptual quantization (PQ) system
 	'hlg': 18, // Rec. ITU-R BT.2100-2 hybrid loggamma (HLG) system
 };
 export const TRANSFER_CHARACTERISTICS_MAP_INVERSE = invertObject(TRANSFER_CHARACTERISTICS_MAP);


### PR DESCRIPTION
Fix for error:
```
Error during decodability check: TypeError: Failed to execute 'isConfigSupported' on 'VideoDecoder': Failed to read the 'colorSpace' property from 'VideoDecoderConfig': Failed to read the 'transfer' property from 'VideoColorSpaceInit': The provided value 'pg' is not a valid enum value of type VideoTransferCharacteristics.
    at InputVideoTrack.canDecode (base-DDKcIYxw.js:5655:42)
```

WebCodecs spec:
https://www.w3.org/TR/webcodecs/#videotransfercharacteristics

Confirmed fix against examples.