### PR TITLE
Explain how to use examples dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ npm run lint # ESLint
 
 npm run docs:generate # Generates API docs
 npm run docs:dev # Start docs development server
-npm run dev # Start examples development server, will run at http://localhost:5173/examples/[name]/index.html
+npm run dev # Start examples development server, will run at http://localhost:5173/examples/[name]/
   
 npm run docs:build # Build docs and examples
 ```


### PR DESCRIPTION
I struggled again to start the examples server.

- I guess this is because it prints `http://localhost:5173`, but it gives a 404
- `http://localhost:5173/examples/media-player` also gives a 404, you have to know to add index.html
- I also tried `cd examples && npm run dev` and `cd examples/media-player && npm run dev` and this starts a Vite server as well, but this is the wrong way of doing it.

Maybe I am an idiot, but I figure it doesn't hurt to be explicit!