### PR TITLE
Don't re-throw reader error when ReadOrchestrator is disposed

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -1466,7 +1466,9 @@ class ReadOrchestrator {
 					worker.pendingSlices.forEach(x => x.reject(error)); // Make sure to propagate any errors
 					worker.pendingSlices.length = 0;
 				} else {
-					throw error; // So it doesn't get swallowed
+					if (!this.disposed) {
+						throw error; // So it doesn't get swallowed
+					}
 				}
 			});
 	}


### PR DESCRIPTION
This solves issue #197 :)

Tested: Without the change, we get an unhandled rejection when switching compositions in Remotion, after the change, it is gone.