### PR TITLE
Ensure FLAC headers are consecutive

### DIFF
--- a/src/flac/flac-demuxer.ts
+++ b/src/flac/flac-demuxer.ts
@@ -339,12 +339,12 @@ export class FlacDemuxer extends Demuxer {
 				slice.skip(-2);
 				const lengthIfNextFlacFrameHeaderIsLegit = slice.filePos - startPos;
 
-				const nextIsLegit = this.readFlacFrameHeader({
+				const nextFrameHeader = this.readFlacFrameHeader({
 					slice,
 					isFirstPacket: false,
 				});
 
-				if (!nextIsLegit) {
+				if (!nextFrameHeader) {
 					slice.skip(-1);
 					continue;
 				}
@@ -354,14 +354,14 @@ export class FlacDemuxer extends Demuxer {
 
 				if (this.blockingBit === 0) {
 					// Case A: If the stream is fixed block size, this is the frame number, which increments by 1
-					if (nextIsLegit.num - frameHeader.num !== 1) {
+					if (nextFrameHeader.num - frameHeader.num !== 1) {
 						slice.skip(-1);
 						continue;
 					}
 				} else {
 					// Case B: If the stream is variable block size, this is the sample number, which increments by
 					// amount of samples in a frame.
-					if (nextIsLegit.num - frameHeader.num !== frameHeader.blockSize) {
+					if (nextFrameHeader.num - frameHeader.num !== frameHeader.blockSize) {
 						slice.skip(-1);
 						continue;
 					}


### PR DESCRIPTION
We were parsing FLAC packages as valid if they had the correct sync code, blocking bit and CRC sum.  
Turns out this can still mean that a packet is not valid, if the `frameOrSampleNum` is not `+ 1` the previous number.

Fixes #194