### PR TITLE
feature(isobmff): read disabled tracks

### DIFF
--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -92,6 +92,7 @@ type InternalTrack = {
 	id: number;
 	demuxer: IsobmffDemuxer;
 	inputTrack: InputTrack | null;
+	isDefault: boolean;
 	timescale: number;
 	durationInMovieTimescale: number;
 	durationInMediaTimescale: number;
@@ -313,6 +314,9 @@ export class IsobmffDemuxer extends Demuxer {
 
 					this.moovSlice = moovSlice;
 					this.readContiguousBoxes(this.moovSlice);
+
+					// Put default tracks first
+					this.tracks.sort((a, b) => Number(b.isDefault) - Number(a.isDefault));
 
 					for (const track of this.tracks) {
 						// Modify the edit list offset based on the previous segment durations. They are in different
@@ -650,6 +654,7 @@ export class IsobmffDemuxer extends Demuxer {
 					id: -1,
 					demuxer: this,
 					inputTrack: null,
+					isDefault: false,
 					info: null,
 					timescale: -1,
 					durationInMovieTimescale: -1,
@@ -692,7 +697,12 @@ export class IsobmffDemuxer extends Demuxer {
 				}
 
 				const version = readU8(slice);
-				slice.skip(3);
+				const flags = readU24Be(slice);
+
+				// Spec says disabled tracks are to be treated like they don't exist, but in practice, they are treated
+				// more like non-default tracks.
+				const trackEnabled = !!(flags & 0x1);
+				track.isDefault = trackEnabled;
 
 				// Skip over creation & modification time to reach the track ID
 				if (version === 0) {


### PR DESCRIPTION
Allows tracks to be parsed even if they are disabled.

Closes #213