### PR TITLE
Use `ArrayBuffer` instead of `ReadableStreamReader`on WebKit browsers

### DIFF
--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -26,7 +26,7 @@ import {
 	insertSorted,
 	isFirefox,
 	isNumber,
-	isSafari,
+	isWebKit,
 	last,
 	mapAsyncGenerator,
 	promiseWithResolvers,
@@ -918,7 +918,7 @@ class VideoDecoderWrapper extends DecoderWrapper<VideoSample> {
 		} else {
 			assert(this.decoder);
 
-			if (!isSafari()) {
+			if (!isWebKit()) {
 				insertSorted(this.inputTimestamps, packet.timestamp, x => x);
 			}
 
@@ -1049,7 +1049,7 @@ class VideoDecoderWrapper extends DecoderWrapper<VideoSample> {
 
 	/** Handler for the WebCodecs VideoDecoder for ironing out browser differences. */
 	sampleHandler(sample: VideoSample) {
-		if (isSafari()) {
+		if (isWebKit()) {
 			// For correct B-frame handling, we don't just hand over the frames directly but instead add them to
 			// a queue, because we want to ensure frames are emitted in presentation order. We flush the queue
 			// each time we receive a frame with a timestamp larger than the highest we've seen so far, as we
@@ -1137,7 +1137,7 @@ class VideoDecoderWrapper extends DecoderWrapper<VideoSample> {
 			this.alphaRaslSkipped = false;
 		}
 
-		if (isSafari()) {
+		if (isWebKit()) {
 			for (const sample of this.sampleQueue) {
 				this.finalizeAndEmitSample(sample);
 			}

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -658,44 +658,17 @@ export class CallSerializer {
 	}
 }
 
-let isSafariCache: boolean | null = null;
-export const isSafari = () => {
-	if (isSafariCache !== null) {
-		return isSafariCache;
-	}
-
-	const result = !!(
-		typeof navigator !== 'undefined'
-		&& navigator.vendor?.match(/apple/i)
-		&& !navigator.userAgent?.match(/crios/i)
-		&& !navigator.userAgent?.match(/fxios/i)
-		&& !navigator.userAgent?.match(/Opera|OPT\//)
-	);
-
-	isSafariCache = result;
-	return result;
-};
-
 let isWebKitCache: boolean | null = null;
 export const isWebKit = () => {
-	if (isWebKitCache !== null) return isWebKitCache;
-	if (typeof navigator === 'undefined') return (isWebKitCache = false);
+	if (isWebKitCache !== null) {
+		return isWebKitCache;
+	}
 
-	const ua = navigator.userAgent || '';
-	const maxTouchPoints = navigator.maxTouchPoints || 0;
+	// This even returns true for WebKit-wrapping browsers such as Chrome on iOS
+	const result = !!(typeof navigator !== 'undefined' && navigator.vendor?.match(/apple/i));
 
-	// iOS/iPadOS detection:
-	// - All iOS/iPadOS browsers use WebKit (WKWebView)
-	// - iPadOS 13+ can report "Macintosh" in UA; detect via touch points
-	const isIOSLike
-    = /iPhone|iPad|iPod/i.test(ua) || (/Macintosh/i.test(ua) && maxTouchPoints > 1);
-
-	// On iOS/iPadOS: always WebKit (even if UA says CriOS/Edg/OPR/etc.)
-	if (isIOSLike) return (isWebKitCache = true);
-
-	// Off iOS: only Safari is WebKit on mainstream desktops
-	const result = isSafari();
-	return (isWebKitCache = result);
+	isWebKitCache = result;
+	return result;
 };
 
 let isFirefoxCache: boolean | null = null;

--- a/src/source.ts
+++ b/src/source.ts
@@ -210,6 +210,7 @@ export class BlobSource extends Source {
 	private async _runWorker(worker: ReadWorker) {
 		let reader = this._readers.get(worker);
 		if (reader === undefined) {
+			// https://github.com/Vanilagy/mediabunny/issues/184
 			// WebKit has critical bugs with blob.stream():
 			// - WebKitBlobResource error 1 when streaming large files
 			// - Memory buildup and reload loops on iOS (network process crashes)


### PR DESCRIPTION
After investigating https://github.com/Vanilagy/mediabunny/issues/184, I found that the problem occurs in WebKit browsers on iOS, especially on devices with lower memory.

Instead of using a `ReadableStreamReader`, we can use `ArrayBuffer` which is much more stable on mobile WebKit browsers. I can't find any definite causes from WebKit source, but I've added some likely reasons in a comment in my changes. This change does not come at a performance cost from my own tests on desktop Safari, obviously doesn't affect other browsers, and it fixes page crashes on WebKit browsers (iOS Safari, iOS Chrome, etc) when uploading large media files.