### PR TITLE
Don't overlook potential packets in FLAC bitstream

### DIFF
--- a/src/flac/flac-demuxer.ts
+++ b/src/flac/flac-demuxer.ts
@@ -334,7 +334,7 @@ export class FlacDemuxer extends Demuxer {
 
 				const expected = this.blockingBit === 1 ? 0b1111_1001 : 0b1111_1000;
 				if (byteAfterNextByte !== expected) {
-					slice.skip(positionBeforeReading - slice.filePos);
+					slice.filePos = positionBeforeReading;
 					continue;
 				}
 
@@ -347,7 +347,7 @@ export class FlacDemuxer extends Demuxer {
 				});
 
 				if (!nextFrameHeader) {
-					slice.skip(positionBeforeReading - slice.filePos);
+					slice.filePos = positionBeforeReading;
 					continue;
 				}
 
@@ -357,14 +357,14 @@ export class FlacDemuxer extends Demuxer {
 				if (this.blockingBit === 0) {
 					// Case A: If the stream is fixed block size, this is the frame number, which increments by 1
 					if (nextFrameHeader.num - frameHeader.num !== 1) {
-						slice.skip(positionBeforeReading - slice.filePos);
+						slice.filePos = positionBeforeReading;
 						continue;
 					}
 				} else {
 					// Case B: If the stream is variable block size, this is the sample number, which increments by
 					// amount of samples in a frame.
 					if (nextFrameHeader.num - frameHeader.num !== frameHeader.blockSize) {
-						slice.skip(positionBeforeReading - slice.filePos);
+						slice.filePos = positionBeforeReading;
 						continue;
 					}
 				}


### PR DESCRIPTION
When we try to parse a FLAC header and it turns out to not be a valid FLAC header, we go back 1 byte.

However, we might have already read a bunch of bytes from the header until we realize that it was not a valid one.
We then need to go back to the beginning, plus 1, to ensure we don't accidentially overlook the beginning of a valid header.

Fixes #217