### PR TITLE
fix: Add cache: 'no-store' to fetch requests to fix Chrome partial content caching issue

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -429,6 +429,10 @@ export class UrlSource extends Source {
 					Range: 'bytes=0-',
 				},
 				signal: abortController.signal,
+				// Bypass browser HTTP cache to avoid issues with partial content caching.
+				// Chrome's cache can fail to revalidate partial entries when CDNs use `vary` headers,
+				// causing range requests to return 200 instead of 206.
+				cache: 'no-store',
 			}),
 			this._getRetryDelay,
 			() => this._disposed,
@@ -497,6 +501,10 @@ export class UrlSource extends Source {
 							Range: `bytes=${worker.currentPos}-`,
 						},
 						signal: abortController.signal,
+						// Bypass browser HTTP cache to avoid issues with partial content caching.
+						// Chrome's cache can fail to revalidate partial entries when CDNs use `vary` headers,
+						// causing range requests to return 200 instead of 206.
+						cache: 'no-store',
 					}),
 					this._getRetryDelay,
 					() => this._disposed,


### PR DESCRIPTION
## Problem

When using `@remotion/media` (via mediabunny) to fetch video files from CDNs that use `vary` headers, Chrome's HTTP cache causes range requests to fail intermittently.

The error manifests as:
```
chrome http_cache_transaction.cc:3401: Failed to revalidate partial entry
Error: Response stream reader stopped unexpectedly before all requested data was read.
```

Or:
```
Error: HTTP server did not respond with 206 Partial Content to a range request.
```

## Root Cause

1. The first range request (`Range: bytes=0-`) succeeds and returns `206 Partial Content`
2. Chrome caches this response with `cache-control: max-age=<n>`
3. Subsequent range requests (e.g., `Range: bytes=<n>-`) trigger Chrome's cache revalidation logic
4. Cache revalidation fails when CDNs use `vary: Origin` or similar headers
5. Chrome falls back to making a non-range request, which returns `200 OK` instead of `206 Partial Content`
6. mediabunny throws an error because it expects `206` for range requests when `worker.currentPos > 0`

This issue is documented in Chrome's source code at `http_cache_transaction.cc:3401` and occurs specifically with partial content (206) responses that have certain cache headers.

## Solution

Added `cache: 'no-store'` to the fetch `RequestInit` options in both `_retrieveSize()` and `_runWorker()` methods. This bypasses Chrome's HTTP cache entirely for media fetches, ensuring that:

- Each range request goes directly to the server
- No partial content caching/revalidation issues occur
- All range requests properly return `206 Partial Content`

## Changes

- `src/source.ts`: Added `cache: 'no-store'` to fetch requests in `UrlSource` class