### PR TITLE
Add support for 2d canvas merger workflow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ export {
 	VIDEO_SAMPLE_PIXEL_FORMATS,
 } from './sample';
 export {
+	AlphaMergerType,
 	AudioBufferSink,
 	AudioSampleSink,
 	BaseMediaSampleSink,
@@ -182,6 +183,7 @@ export {
 	EncodedPacketSink,
 	PacketRetrievalOptions,
 	VideoSampleSink,
+	VideoSampleSinkOptions,
 	WrappedAudioBuffer,
 	WrappedCanvas,
 } from './media-sink';


### PR DESCRIPTION
On my tests, 2d canvas merger is 2-3x faster than webgl version when I run it inside puppeteer instance.
I don't know if it is possible to automatically detect which one is faster/better and use by default.
So maybe a user should control that.