### PR TITLE
Set max one worker for UrlSource

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -416,9 +416,7 @@ export class UrlSource extends Source {
 
 		this._orchestrator = new ReadOrchestrator({
 			maxCacheSize: options.maxCacheSize ?? (64 * 2 ** 20 /* 64 MiB */),
-			// Most files in the real-world have a single sequential access pattern, but having two in parallel can
-			// also happen
-			maxWorkerCount: 2,
+			maxWorkerCount: 1, // Chromium has been seen to have problem with more than one worker
 			runWorker: this._runWorker.bind(this),
 			prefetchProfile: PREFETCH_PROFILES.network,
 		});


### PR DESCRIPTION
In my React app, Chrome sometimes got stuck in a pending state for a partial request of an MP4 file. Setting maxWorkerCount to 1 solved the problem. This fixes issue #284 