### PR TITLE
Add UrlSourceOptions.parallelism

### DIFF
--- a/docs/guide/reading-media-files.md
+++ b/docs/guide/reading-media-files.md
@@ -506,6 +506,9 @@ type UrlSourceOptions = {
 	// in memory. Defaults to 8 MiB.
 	maxCacheSize?: number;
 
+	// The maximum number of parallel requests to use for fetching. Defaults to 2.
+	parallelism?: number;
+
 	// Used to provide a custom fetch function
 	fetchFn?: typeof fetch;
 };


### PR DESCRIPTION
This add the option to specify the maximum number of workers for fetching from a URL.
It is motivated by having seen Chromium to sometimes have trouble with parallel workers for fetching.
This solves issue #289.