### PR TITLE
Add MP4 chapter track refs, optional nero-chpl, and Apple audiobook profile

### DIFF
--- a/docs/guide/writing-media-files.md
+++ b/docs/guide/writing-media-files.md
@@ -107,6 +107,31 @@ output.addAudioTrack(audioSource);
 Adding tracks to an `Output` will throw if the track is not compatible with the output format. Be sure to respect the [properties](./output-formats#format-properties) of the output format when adding tracks.
 :::
 
+## ISOBMFF chapter references
+
+When writing MP4/MOV files, you can mark a subtitle track as the chapter track of an audio track by using
+`setChapterTrackReference(trackId, chapterTrackId)`:
+
+```ts
+const output = new Output({
+	format: new Mp4OutputFormat(),
+	target: new BufferTarget(),
+});
+
+const audioSource = new EncodedAudioPacketSource('aac');
+const chapterSource = new TextSubtitleSource('webvtt');
+
+output.addAudioTrack(audioSource); // track id 1
+output.addSubtitleTrack(chapterSource, {
+	name: 'Chapters',
+	disposition: { default: false }, // Optional: keep chapter track hidden by default
+}); // track id 2
+
+output.setChapterTrackReference(1, 2); // Writes tref/chap
+```
+
+This writes an ISOBMFF `tref/chap` reference from the audio track to the subtitle track.
+
 ## Setting metadata tags
 
 Mediabunny lets you write additional descriptive metadata tags to an output file, such as title, artist, or cover art:

--- a/docs/guide/writing-media-files.md
+++ b/docs/guide/writing-media-files.md
@@ -146,6 +146,35 @@ const output = new Output({
 
 This keeps `tref/chap` and additionally writes a `moov/udta/chpl` chapter list.
 
+## Apple audiobook profile (M4B)
+
+For Apple Books / iTunes-style audiobook compatibility, enable `appleAudiobook` on `Mp4OutputFormat`:
+
+```ts
+const output = new Output({
+	format: new Mp4OutputFormat({
+		appleAudiobook: true,
+	}),
+	target: new BufferTarget(),
+});
+```
+
+When enabled, Mediabunny writes MP4 branding and metadata commonly expected for audiobooks:
+- `ftyp` major brand `M4B ` with compatible brands `M4A ` and `isom`
+- iTunes media type tag `stik=2` (audiobook)
+
+For chaptered audiobooks, combine this with chapter track references and optional Nero chapter atoms:
+
+```ts
+const output = new Output({
+	format: new Mp4OutputFormat({
+		appleAudiobook: true,
+		chapterFormat: 'tref+nero-chpl',
+	}),
+	target: new BufferTarget(),
+});
+```
+
 ## Setting metadata tags
 
 Mediabunny lets you write additional descriptive metadata tags to an output file, such as title, artist, or cover art:

--- a/docs/guide/writing-media-files.md
+++ b/docs/guide/writing-media-files.md
@@ -132,6 +132,20 @@ output.setChapterTrackReference(1, 2); // Writes tref/chap
 
 This writes an ISOBMFF `tref/chap` reference from the audio track to the subtitle track.
 
+By default, Mediabunny writes only `tref/chap`. If you need compatibility with players that expect Nero-style chapter
+atoms (for example, some VLC setups), enable `chapterFormat: 'tref+nero-chpl'`:
+
+```ts
+const output = new Output({
+	format: new Mp4OutputFormat({
+		chapterFormat: 'tref+nero-chpl',
+	}),
+	target: new BufferTarget(),
+});
+```
+
+This keeps `tref/chap` and additionally writes a `moov/udta/chpl` chapter list.
+
 ## Setting metadata tags
 
 Mediabunny lets you write additional descriptive metadata tags to an output file, such as title, artist, or cover art:

--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -385,9 +385,11 @@ export const mvhd = (
  */
 export const trak = (trackData: IsobmffTrackData, creationTime: number) => {
 	const trackMetadata = getTrackMetadata(trackData);
+	const chapterTrackReferences = trackData.track.output._isobmffChapterTrackReferences.get(trackData.track.id) ?? [];
 
 	return box('trak', undefined, [
 		tkhd(trackData, creationTime),
+		chapterTrackReferences.length > 0 ? tref('chap', chapterTrackReferences) : null,
 		mdia(trackData, creationTime),
 		trackMetadata.name !== undefined
 			? box('udta', undefined, [
@@ -398,6 +400,11 @@ export const trak = (trackData: IsobmffTrackData, creationTime: number) => {
 			: null,
 	]);
 };
+
+/** Track Reference Box. */
+export const tref = (referenceType: string, trackIds: number[]) => box('tref', undefined, [
+	box(referenceType, trackIds.map(trackId => u32(trackId))),
+]);
 
 /** Track Header Box: Specifies the characteristics of a single track within a movie. */
 export const tkhd = (

--- a/src/isobmff/isobmff-misc.ts
+++ b/src/isobmff/isobmff-misc.ts
@@ -27,3 +27,16 @@ export const buildIsobmffMimeType = (info: {
 
 	return string;
 };
+
+export const isReferencedTrackId = (
+	references: ReadonlyMap<number, readonly number[]>,
+	trackId: number,
+) => {
+	for (const referencedTrackIds of references.values()) {
+		if (referencedTrackIds.includes(trackId)) {
+			return true;
+		}
+	}
+
+	return false;
+};

--- a/src/isobmff/isobmff-muxer.ts
+++ b/src/isobmff/isobmff-muxer.ts
@@ -219,6 +219,7 @@ export class IsobmffMuxer extends Muxer {
 				isQuickTime: this.isQuickTime,
 				holdsAvc: holdsAvc,
 				fragmented: this.isFragmented,
+				appleAudiobook: !!this.format._options.appleAudiobook,
 			}));
 
 			if (this.format._options.onFtyp) {

--- a/src/isobmff/isobmff-muxer.ts
+++ b/src/isobmff/isobmff-muxer.ts
@@ -120,6 +120,7 @@ export type IsobmffTrackData = {
 	};
 	lastCueEndTimestamp: number;
 	cueQueue: SubtitleCue[];
+	allCues: SubtitleCue[];
 	nextSourceId: number;
 	cueToSourceId: WeakMap<SubtitleCue, number>;
 });
@@ -485,6 +486,7 @@ export class IsobmffMuxer extends Muxer {
 
 			lastCueEndTimestamp: 0,
 			cueQueue: [],
+			allCues: [],
 			nextSourceId: 0,
 			cueToSourceId: new WeakMap(),
 		};
@@ -619,6 +621,7 @@ export class IsobmffMuxer extends Muxer {
 
 		try {
 			const trackData = this.getSubtitleTrackData(track, meta);
+			trackData.allCues.push(cue);
 
 			this.validateAndNormalizeTimestamp(trackData.track, cue.timestamp, true);
 

--- a/src/isobmff/isobmff-muxer.ts
+++ b/src/isobmff/isobmff-muxer.ts
@@ -10,7 +10,7 @@ import { Box, free, ftyp, IsobmffBoxWriter, mdat, mfra, moof, moov, vtta, vttc, 
 import { Muxer } from '../muxer';
 import { Output, OutputAudioTrack, OutputSubtitleTrack, OutputTrack, OutputVideoTrack } from '../output';
 import { BufferTargetWriter, Writer } from '../writer';
-import { assert, computeRationalApproximation, last, promiseWithResolvers } from '../misc';
+import { assert, computeRationalApproximation, last, promiseWithResolvers, textEncoder } from '../misc';
 import { IsobmffOutputFormatOptions, IsobmffOutputFormat, MovOutputFormat } from '../output-format';
 import { inlineTimestampRegex, SubtitleConfig, SubtitleCue, SubtitleMetadata } from '../subtitles';
 import {
@@ -37,7 +37,7 @@ import {
 	serializeAvcDecoderConfigurationRecord,
 	serializeHevcDecoderConfigurationRecord,
 } from '../codec-data';
-import { buildIsobmffMimeType } from './isobmff-misc';
+import { buildIsobmffMimeType, isReferencedTrackId } from './isobmff-misc';
 import { MAX_BOX_HEADER_SIZE, MIN_BOX_HEADER_SIZE } from './isobmff-reader';
 
 export const GLOBAL_TIMESCALE = 1000;
@@ -175,6 +175,12 @@ export class IsobmffMuxer extends Muxer {
 	// Only relevant for fragmented files, to make sure new fragments start with the highest timestamp seen so far
 	private maxWrittenTimestamp = -Infinity;
 	private minimumFragmentDuration: number;
+
+	private static CHAPTER_TEXT_MODIFIER_SAMPLE = /* #__PURE__ */ new Uint8Array([
+		0x00, 0x00, 0x00, 0x0c, // box size
+		0x65, 0x6e, 0x63, 0x64, // 'encd'
+		0x00, 0x00, 0x01, 0x00,
+	]);
 
 	constructor(output: Output, format: IsobmffOutputFormat) {
 		super(output);
@@ -627,7 +633,11 @@ export class IsobmffMuxer extends Muxer {
 
 			if (track.source._codec === 'webvtt') {
 				trackData.cueQueue.push(cue);
-				await this.processWebVTTCues(trackData, cue.timestamp);
+				if (this.isChapterTrack(trackData)) {
+					await this.processChapterTextCues(trackData, cue.timestamp);
+				} else {
+					await this.processWebVTTCues(trackData, cue.timestamp);
+				}
 			} else {
 				// TODO
 			}
@@ -726,6 +736,73 @@ export class IsobmffMuxer extends Muxer {
 
 			await this.registerSample(trackData, sample);
 			trackData.lastCueEndTimestamp = sampleEnd;
+		}
+	}
+
+	private isChapterTrack(trackData: IsobmffSubtitleTrackData) {
+		return isReferencedTrackId(
+			trackData.track.output._isobmffChapterTrackReferences,
+			trackData.track.id,
+		);
+	}
+
+	private normalizeChapterCueText(text: string) {
+		return text
+			.replaceAll('\r\n', '\n')
+			.replaceAll('\r', '\n')
+			.split('\n')
+			.map(line => line.trim())
+			.filter(line => line.length > 0)
+			.join(' ');
+	}
+
+	private truncateUtf8(text: string, maxBytes: number) {
+		let result = '';
+		let bytesUsed = 0;
+
+		for (const character of text) {
+			const encodedCharacter = textEncoder.encode(character);
+			if (bytesUsed + encodedCharacter.byteLength > maxBytes) {
+				break;
+			}
+
+			result += character;
+			bytesUsed += encodedCharacter.byteLength;
+		}
+
+		return textEncoder.encode(result);
+	}
+
+	private createChapterTextSample(cue: SubtitleCue) {
+		const normalizedText = this.normalizeChapterCueText(cue.text);
+		const textBytes = this.truncateUtf8(normalizedText, 0xffff);
+		const data = new Uint8Array(
+			2 + textBytes.byteLength + IsobmffMuxer.CHAPTER_TEXT_MODIFIER_SAMPLE.byteLength,
+		);
+
+		data[0] = textBytes.byteLength >> 8;
+		data[1] = textBytes.byteLength & 0xff;
+		data.set(textBytes, 2);
+		data.set(
+			IsobmffMuxer.CHAPTER_TEXT_MODIFIER_SAMPLE,
+			2 + textBytes.byteLength,
+		);
+
+		return data;
+	}
+
+	private async processChapterTextCues(trackData: IsobmffSubtitleTrackData, until: number) {
+		while (trackData.cueQueue.length > 0 && trackData.cueQueue[0]!.timestamp <= until) {
+			const cue = trackData.cueQueue.shift()!;
+			const cueDuration = Math.max(cue.duration, 0.001);
+			const sample = this.createSampleForTrack(
+				trackData,
+				this.createChapterTextSample(cue),
+				cue.timestamp,
+				cueDuration,
+				'key',
+			);
+			await this.registerSample(trackData, sample);
 		}
 	}
 
@@ -1240,7 +1317,11 @@ export class IsobmffMuxer extends Muxer {
 		if (track.type === 'subtitle' && track.source._codec === 'webvtt') {
 			const trackData = this.trackDatas.find(x => x.track === track) as IsobmffSubtitleTrackData;
 			if (trackData) {
-				await this.processWebVTTCues(trackData, Infinity);
+				if (this.isChapterTrack(trackData)) {
+					await this.processChapterTextCues(trackData, Infinity);
+				} else {
+					await this.processWebVTTCues(trackData, Infinity);
+				}
 			}
 		}
 
@@ -1264,7 +1345,11 @@ export class IsobmffMuxer extends Muxer {
 
 		for (const trackData of this.trackDatas) {
 			if (trackData.type === 'subtitle' && trackData.track.source._codec === 'webvtt') {
-				await this.processWebVTTCues(trackData, Infinity);
+				if (this.isChapterTrack(trackData)) {
+					await this.processChapterTextCues(trackData, Infinity);
+				} else {
+					await this.processWebVTTCues(trackData, Infinity);
+				}
 			}
 		}
 

--- a/src/output-format.ts
+++ b/src/output-format.ts
@@ -163,6 +163,16 @@ export type IsobmffOutputFormatOptions = {
 	chapterFormat?: 'tref' | 'tref+nero-chpl';
 
 	/**
+	 * Enables Apple audiobook compatibility mode for MP4 outputs.
+	 *
+	 * When enabled, MP4 files are branded as audiobook files (`M4B ` major brand with `M4A ` and `isom` compatible
+	 * brands), and the iTunes media type metadata atom (`stik`) is written as audiobook (`2`).
+	 *
+	 * Defaults to `false`.
+	 */
+	appleAudiobook?: boolean;
+
+	/**
 	 * Will be called once the ftyp (File Type) box of the output file has been written.
 	 *
 	 * @param data - The raw bytes.
@@ -253,6 +263,9 @@ export abstract class IsobmffOutputFormat extends OutputFormat {
 			throw new TypeError(
 				'options.chapterFormat, when provided, must be either \'tref\' or \'tref+nero-chpl\'.',
 			);
+		}
+		if (options.appleAudiobook !== undefined && typeof options.appleAudiobook !== 'boolean') {
+			throw new TypeError('options.appleAudiobook, when provided, must be a boolean.');
 		}
 
 		super();

--- a/src/output-format.ts
+++ b/src/output-format.ts
@@ -154,6 +154,15 @@ export type IsobmffOutputFormatOptions = {
 	metadataFormat?: 'auto' | 'mdir' | 'mdta' | 'udta';
 
 	/**
+	 * Controls which chapter structures are written when using {@link Output.setChapterTrackReference}.
+	 *
+	 * - `'tref'` (default): Write ISOBMFF `tref/chap` references only.
+	 * - `'tref+nero-chpl'`: Write `tref/chap` references and an additional `udta/chpl` chapter list, improving
+	 * compatibility with players that rely on Nero chapter atoms.
+	 */
+	chapterFormat?: 'tref' | 'tref+nero-chpl';
+
+	/**
 	 * Will be called once the ftyp (File Type) box of the output file has been written.
 	 *
 	 * @param data - The raw bytes.
@@ -235,6 +244,14 @@ export abstract class IsobmffOutputFormat extends OutputFormat {
 		) {
 			throw new TypeError(
 				'options.metadataFormat, when provided, must be either \'auto\', \'mdir\', \'mdta\', or \'udta\'.',
+			);
+		}
+		if (
+			options.chapterFormat !== undefined
+			&& !['tref', 'tref+nero-chpl'].includes(options.chapterFormat)
+		) {
+			throw new TypeError(
+				'options.chapterFormat, when provided, must be either \'tref\' or \'tref+nero-chpl\'.',
 			);
 		}
 

--- a/test/node/chapter-track-reference.test.ts
+++ b/test/node/chapter-track-reference.test.ts
@@ -1,0 +1,180 @@
+import { expect, test } from 'vitest';
+import { buildAacAudioSpecificConfig } from '../../src/codec.js';
+import { EncodedAudioPacketSource, TextSubtitleSource } from '../../src/media-source.js';
+import { Output } from '../../src/output.js';
+import { Mp4OutputFormat } from '../../src/output-format.js';
+import { EncodedPacket } from '../../src/packet.js';
+import { BufferTarget } from '../../src/target.js';
+
+type ParsedBox = {
+	type: string;
+	start: number;
+	end: number;
+	contentStart: number;
+	contentEnd: number;
+	children: ParsedBox[];
+};
+
+const CONTAINER_BOX_TYPES = new Set([
+	'moov',
+	'trak',
+	'mdia',
+	'tref',
+]);
+
+const boxTypeFrom = (bytes: Uint8Array, offset: number) => {
+	return String.fromCharCode(
+		bytes[offset]!,
+		bytes[offset + 1]!,
+		bytes[offset + 2]!,
+		bytes[offset + 3]!,
+	);
+};
+
+const readU32 = (bytes: Uint8Array, offset: number) => {
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	return view.getUint32(offset, false);
+};
+
+const readU64 = (bytes: Uint8Array, offset: number) => {
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	return Number(view.getBigUint64(offset, false));
+};
+
+const parseBoxes = (bytes: Uint8Array, start: number, end: number): ParsedBox[] => {
+	const boxes: ParsedBox[] = [];
+	let offset = start;
+
+	while (offset + 8 <= end) {
+		let size = readU32(bytes, offset);
+		const type = boxTypeFrom(bytes, offset + 4);
+		let headerSize = 8;
+
+		if (size === 1) {
+			if (offset + 16 > end) break;
+			size = readU64(bytes, offset + 8);
+			headerSize = 16;
+		} else if (size === 0) {
+			size = end - offset;
+		}
+
+		if (size < headerSize || offset + size > end) break;
+
+		const contentStart = offset + headerSize;
+		const contentEnd = offset + size;
+		const box: ParsedBox = {
+			type,
+			start: offset,
+			end: contentEnd,
+			contentStart,
+			contentEnd,
+			children: CONTAINER_BOX_TYPES.has(type)
+				? parseBoxes(bytes, contentStart, contentEnd)
+				: [],
+		};
+
+		boxes.push(box);
+		offset += size;
+	}
+
+	return boxes;
+};
+
+type TrackSnapshot = {
+	trackId: number;
+	handlerType: string | null;
+	chapterTrackIds: number[];
+};
+
+const parseTrackSnapshots = (mp4: Uint8Array): TrackSnapshot[] => {
+	const topLevel = parseBoxes(mp4, 0, mp4.byteLength);
+	const moov = topLevel.find((box) => box.type === 'moov');
+	expect(moov).toBeTruthy();
+
+	const tracks = moov!.children.filter((box) => box.type === 'trak');
+	return tracks.map((trak): TrackSnapshot => {
+		const tkhd = trak.children.find((box) => box.type === 'tkhd');
+		expect(tkhd).toBeTruthy();
+
+		const version = mp4[tkhd!.contentStart]!;
+		const trackIdOffset = tkhd!.contentStart + (version === 1 ? 20 : 12);
+		const trackId = readU32(mp4, trackIdOffset);
+
+		const mdia = trak.children.find((box) => box.type === 'mdia');
+		const hdlr = mdia?.children.find((box) => box.type === 'hdlr') ?? null;
+		const handlerType = hdlr
+			? boxTypeFrom(mp4, hdlr.contentStart + 8)
+			: null;
+
+		const tref = trak.children.find((box) => box.type === 'tref');
+		const chap = tref?.children.find((box) => box.type === 'chap') ?? null;
+		const chapterTrackIds: number[] = [];
+		if (chap) {
+			for (let offset = chap.contentStart; offset + 4 <= chap.contentEnd; offset += 4) {
+				chapterTrackIds.push(readU32(mp4, offset));
+			}
+		}
+
+		return { trackId, handlerType, chapterTrackIds };
+	});
+};
+
+test('MP4 chapter track references are written as tref/chap', async () => {
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+
+	const audioSource = new EncodedAudioPacketSource('aac');
+	const subtitleSource = new TextSubtitleSource('webvtt');
+
+	output.addAudioTrack(audioSource, { name: 'Main Audio' });
+	output.addSubtitleTrack(subtitleSource, {
+		name: 'Chapters',
+		disposition: { default: false },
+	});
+	output.setChapterTrackReference(1, 2);
+
+	await output.start();
+
+	await audioSource.add(new EncodedPacket(new Uint8Array([0x12, 0x10, 0x56]), 'key', 0, 1), {
+		decoderConfig: {
+			codec: 'mp4a.40.2',
+			sampleRate: 24000,
+			numberOfChannels: 1,
+			description: buildAacAudioSpecificConfig({
+				objectType: 2,
+				sampleRate: 24000,
+				numberOfChannels: 1,
+			}),
+		},
+	});
+	await subtitleSource.add('WEBVTT\n\n00:00.000 --> 00:01.000\nPage 1\n');
+
+	audioSource.close();
+	subtitleSource.close();
+	await output.finalize();
+
+	const fileBytes = new Uint8Array(output.target.buffer!);
+	const tracks = parseTrackSnapshots(fileBytes);
+
+	const audioTrack = tracks.find((track) => track.handlerType === 'soun');
+	const chapterTrack = tracks.find((track) => track.handlerType === 'text');
+	expect(audioTrack).toBeTruthy();
+	expect(chapterTrack).toBeTruthy();
+	expect(audioTrack!.chapterTrackIds).toEqual([chapterTrack!.trackId]);
+});
+
+test('setChapterTrackReference validates that track IDs exist', () => {
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+
+	const audioSource = new EncodedAudioPacketSource('aac');
+	const subtitleSource = new TextSubtitleSource('webvtt');
+	output.addAudioTrack(audioSource);
+	output.addSubtitleTrack(subtitleSource);
+
+	expect(() => output.setChapterTrackReference(1, 3)).toThrow(/track id/i);
+});

--- a/test/node/mp4-audiobook-profile.test.ts
+++ b/test/node/mp4-audiobook-profile.test.ts
@@ -1,0 +1,200 @@
+import { expect, test } from 'vitest';
+import { buildAacAudioSpecificConfig } from '../../src/codec.js';
+import { EncodedAudioPacketSource } from '../../src/media-source.js';
+import { Output } from '../../src/output.js';
+import { Mp4OutputFormat } from '../../src/output-format.js';
+import { EncodedPacket } from '../../src/packet.js';
+import { BufferTarget } from '../../src/target.js';
+
+type ParsedBox = {
+	type: string;
+	start: number;
+	end: number;
+	contentStart: number;
+	contentEnd: number;
+	children: ParsedBox[];
+};
+
+const CONTAINER_BOX_TYPES = new Set([
+	'moov',
+	'trak',
+	'mdia',
+	'minf',
+	'stbl',
+	'tref',
+	'udta',
+	'meta',
+	'ilst',
+]);
+
+const boxTypeFrom = (bytes: Uint8Array, offset: number) => {
+	return String.fromCharCode(
+		bytes[offset]!,
+		bytes[offset + 1]!,
+		bytes[offset + 2]!,
+		bytes[offset + 3]!,
+	);
+};
+
+const readU32 = (bytes: Uint8Array, offset: number) => {
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	return view.getUint32(offset, false);
+};
+
+const readU64 = (bytes: Uint8Array, offset: number) => {
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	return Number(view.getBigUint64(offset, false));
+};
+
+const parseBoxes = (bytes: Uint8Array, start: number, end: number): ParsedBox[] => {
+	const boxes: ParsedBox[] = [];
+	let offset = start;
+
+	while (offset + 8 <= end) {
+		let size = readU32(bytes, offset);
+		const type = boxTypeFrom(bytes, offset + 4);
+		let headerSize = 8;
+
+		if (size === 1) {
+			if (offset + 16 > end) break;
+			size = readU64(bytes, offset + 8);
+			headerSize = 16;
+		} else if (size === 0) {
+			size = end - offset;
+		}
+
+		if (size < headerSize || offset + size > end) break;
+
+		const contentStart = offset + headerSize;
+		const contentEnd = offset + size;
+		const childStart = type === 'meta'
+			? Math.min(contentEnd, contentStart + 4)
+			: contentStart;
+		const box: ParsedBox = {
+			type,
+			start: offset,
+			end: contentEnd,
+			contentStart,
+			contentEnd,
+			children: CONTAINER_BOX_TYPES.has(type)
+				? parseBoxes(bytes, childStart, contentEnd)
+				: [],
+		};
+
+		boxes.push(box);
+		offset += size;
+	}
+
+	return boxes;
+};
+
+type FtypSnapshot = {
+	majorBrand: string;
+	minorVersion: number;
+	compatibleBrands: string[];
+};
+
+const parseFtypSnapshot = (mp4: Uint8Array): FtypSnapshot => {
+	const topLevel = parseBoxes(mp4, 0, mp4.byteLength);
+	const ftyp = topLevel.find((box) => box.type === 'ftyp');
+	expect(ftyp).toBeTruthy();
+
+	const majorBrand = boxTypeFrom(mp4, ftyp!.contentStart);
+	const minorVersion = readU32(mp4, ftyp!.contentStart + 4);
+	const compatibleBrands: string[] = [];
+
+	for (let offset = ftyp!.contentStart + 8; offset + 4 <= ftyp!.contentEnd; offset += 4) {
+		compatibleBrands.push(boxTypeFrom(mp4, offset));
+	}
+
+	return { majorBrand, minorVersion, compatibleBrands };
+};
+
+type DataEntry = {
+	typeIndicator: number;
+	payload: Uint8Array;
+};
+
+const parseMetadataDataEntry = (mp4: Uint8Array, key: string): DataEntry | null => {
+	const topLevel = parseBoxes(mp4, 0, mp4.byteLength);
+	const moov = topLevel.find((box) => box.type === 'moov');
+	if (!moov) return null;
+
+	const udta = moov.children.find((box) => box.type === 'udta');
+	if (!udta) return null;
+
+	const meta = udta.children.find((box) => box.type === 'meta');
+	if (!meta) return null;
+
+	const ilst = meta.children.find((box) => box.type === 'ilst');
+	if (!ilst) return null;
+
+	const entry = ilst.children.find((box) => box.type === key);
+	if (!entry) return null;
+
+	const data = parseBoxes(mp4, entry.contentStart, entry.contentEnd)
+		.find((box) => box.type === 'data');
+	if (!data || data.contentStart + 8 > data.contentEnd) return null;
+
+	const typeIndicator = readU32(mp4, data.contentStart);
+	const payload = mp4.subarray(data.contentStart + 8, data.contentEnd);
+	return { typeIndicator, payload };
+};
+
+const writeSinglePacketMp4 = async (format: Mp4OutputFormat) => {
+	const output = new Output({
+		format,
+		target: new BufferTarget(),
+	});
+
+	output.setMetadataTags({ title: 'Book' });
+
+	const source = new EncodedAudioPacketSource('aac');
+	output.addAudioTrack(source);
+
+	await output.start();
+	await source.add(new EncodedPacket(new Uint8Array([0x12, 0x10, 0x56]), 'key', 0, 1), {
+		decoderConfig: {
+			codec: 'mp4a.40.2',
+			sampleRate: 24000,
+			numberOfChannels: 1,
+			description: buildAacAudioSpecificConfig({
+				objectType: 2,
+				sampleRate: 24000,
+				numberOfChannels: 1,
+			}),
+		},
+	});
+	source.close();
+	await output.finalize();
+
+	return new Uint8Array(output.target.buffer!);
+};
+
+test('MP4 default branding and metadata stay unchanged', async () => {
+	const bytes = await writeSinglePacketMp4(new Mp4OutputFormat());
+	const ftyp = parseFtypSnapshot(bytes);
+
+	expect(ftyp.majorBrand).toBe('isom');
+	expect(ftyp.minorVersion).toBe(0x200);
+	expect(ftyp.compatibleBrands).toContain('isom');
+	expect(ftyp.compatibleBrands).toContain('mp41');
+
+	expect(parseMetadataDataEntry(bytes, 'stik')).toBeNull();
+});
+
+test('MP4 appleAudiobook mode writes M4B brand and stik=2 metadata', async () => {
+	const bytes = await writeSinglePacketMp4(new Mp4OutputFormat({ appleAudiobook: true }));
+	const ftyp = parseFtypSnapshot(bytes);
+
+	expect(ftyp.majorBrand).toBe('M4B ');
+	expect(ftyp.minorVersion).toBe(0);
+	expect(ftyp.compatibleBrands).toContain('M4A ');
+	expect(ftyp.compatibleBrands).toContain('isom');
+	expect(ftyp.compatibleBrands).not.toContain('mp41');
+
+	const stik = parseMetadataDataEntry(bytes, 'stik');
+	expect(stik).toBeTruthy();
+	expect(stik!.typeIndicator).toBe(21);
+	expect(Array.from(stik!.payload)).toEqual([2]);
+});


### PR DESCRIPTION
This PR adds all the necessary pieces for MP4B output support. This includes chapter-track references, optional nero-chpl output, and an opt-in Apple audiobook MP4 profile, with tests and docs updates.
I am a novice in this code - written with copious help from Claude.
I've vendored it and it works for me (TM) - in that apple books happily eats the output and allows one to jump between chapters - but I thought I'd try to upstream. TODO: chapter art support.