### PR TITLE
Fix HEVC fMP4 demuxing: deserialize hvcC box

### DIFF
--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -22,6 +22,7 @@ import {
 import {
 	Av1CodecInfo,
 	AvcDecoderConfigurationRecord,
+	deserializeHevcDecoderConfigurationRecord,
 	extractAv1CodecInfoFromPacket,
 	extractVp9CodecInfoFromPacket,
 	FlacBlockType,
@@ -1102,7 +1103,12 @@ export class IsobmffDemuxer extends Demuxer {
 				}
 				assert(track.info);
 
-				track.info.codecDescription = readBytes(slice, boxInfo.contentSize);
+				const hvcCBytes = readBytes(slice, boxInfo.contentSize);
+				track.info.codecDescription = hvcCBytes;
+
+				if (track.info.type === 'video') {
+					track.info.hevcCodecInfo = deserializeHevcDecoderConfigurationRecord(hvcCBytes);
+				}
 			}; break;
 
 			case 'vpcC': {


### PR DESCRIPTION
## Problem

When trying to demux HEVC fMP4 segments (e.g. from HLS streams with `hvc1` codec), mediabunny throws:

```
Error: Input has an unsupported or unrecognizable format.
```

This happens even though the ISOBMFF demuxer correctly recognizes the `hvc1`/`hev1` sample entry box and sets `codec = 'hevc'`.

## Root cause

The `hvcC` configuration box is read as raw bytes into `codecDescription` but never deserialized into the typed `HevcDecoderConfigurationRecord`. When `extractVideoCodecString()` runs, `hevcCodecInfo` is `null`, so it falls back to manual byte-offset parsing of `codecDescription` — which throws if the data doesn't match expected offsets.

Compare with VP9 (`vpcC`) and AV1 (`av1C`) which both properly parse their config boxes into typed structs during demuxing. The MPEG-TS demuxer also already calls `deserializeHevcDecoderConfigurationRecord()` for HEVC.

## Fix

Call `deserializeHevcDecoderConfigurationRecord()` (already exists in `codec-data.ts`) when parsing the `hvcC` box, storing the result in `track.info.hevcCodecInfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)