### PR TITLE
pixel aspect ration support

### DIFF
--- a/docs/guide/reading-media-files.md
+++ b/docs/guide/reading-media-files.md
@@ -220,13 +220,19 @@ In addition to the [common track metadata](#common-track-metadata), video tracks
 videoTrack.codedWidth; // => number
 videoTrack.codedHeight; // => number
 
-// Get the displayed pixel dimensions of the track's samples, after rotation:
+// Get the displayed pixel dimensions of the track's samples,
+// after rotation and pixel aspect ratio scaling:
 videoTrack.displayWidth; // => number
 videoTrack.displayHeight; // => number
 
 // Get the clockwise rotation in degrees by which the
 // track's frames should be rotated:
 videoTrack.rotation; // => 0 | 90 | 180 | 270
+
+// Get the pixel aspect ratio (hSpacing:vSpacing).
+// For most modern videos this is 1:1 (square pixels):
+videoTrack.hSpacing; // => number
+videoTrack.vSpacing; // => number
 ```
 
 To compute a video track's average frame rate (FPS), use [`computePacketStats`](#packet-statistics):

--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -643,6 +643,12 @@ export const colr = (trackData: IsobmffVideoTrackData) => box('colr', [
 	u8((trackData.info.decoderConfig.colorSpace!.fullRange ? 1 : 0) << 7), // Full range flag
 ]);
 
+/** Pixel Aspect Ratio Box: Specifies the pixel aspect ratio of the video. */
+export const pasp = (hSpacing: number, vSpacing: number) => box('pasp', [
+	u32(hSpacing), // hSpacing: horizontal extent of a pixel
+	u32(vSpacing), // vSpacing: vertical extent of a pixel
+]);
+
 /** AVC Configuration Box: Provides additional information to the decoder. */
 export const avcC = (trackData: IsobmffVideoTrackData) => trackData.info.decoderConfig && box('avcC', [
 	// For AVC, description is an AVCDecoderConfigurationRecord, so nothing else to do here

--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -129,6 +129,8 @@ type InternalTrack = {
 		type: 'video';
 		width: number;
 		height: number;
+		hSpacing: number;
+		vSpacing: number;
 		codec: VideoCodec | null;
 		codecDescription: Uint8Array | null;
 		colorSpace: VideoColorSpaceInit | null;
@@ -846,6 +848,8 @@ export class IsobmffDemuxer extends Demuxer {
 						type: 'video',
 						width: -1,
 						height: -1,
+						hSpacing: 1,
+						vSpacing: 1,
 						codec: null,
 						codecDescription: null,
 						colorSpace: null,
@@ -1196,6 +1200,17 @@ export class IsobmffDemuxer extends Demuxer {
 					matrix: MATRIX_COEFFICIENTS_MAP_INVERSE[matrixCoefficients],
 					fullRange: fullRangeFlag,
 				} as VideoColorSpaceInit;
+			}; break;
+
+			case 'pasp': {
+				const track = this.currentTrack;
+				if (!track) {
+					break;
+				}
+				assert(track.info?.type === 'video');
+
+				track.info.hSpacing = readU32Be(slice);
+				track.info.vSpacing = readU32Be(slice);
 			}; break;
 
 			case 'wave': {
@@ -2883,6 +2898,14 @@ class IsobmffVideoTrackBacking extends IsobmffTrackBacking implements InputVideo
 
 	getCodedHeight() {
 		return this.internalTrack.info.height;
+	}
+
+	getHSpacing() {
+		return this.internalTrack.info.hSpacing;
+	}
+
+	getVSpacing() {
+		return this.internalTrack.info.vSpacing;
 	}
 
 	getRotation() {

--- a/src/matroska/matroska-demuxer.ts
+++ b/src/matroska/matroska-demuxer.ts
@@ -2337,6 +2337,14 @@ class MatroskaVideoTrackBacking extends MatroskaTrackBacking implements InputVid
 		return this.internalTrack.info.height;
 	}
 
+	getHSpacing() {
+		return 1;
+	}
+
+	getVSpacing() {
+		return 1;
+	}
+
 	getRotation() {
 		return this.internalTrack.info.rotation;
 	}

--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -1588,8 +1588,11 @@ export class CanvasSink {
 		}
 
 		let [width, height] = crop
-			? [crop.width, crop.height]
-			: [rotatedWidth, rotatedHeight];
+			? [
+				Math.round(crop.width * videoTrack.displayWidth / rotatedWidth),
+				Math.round(crop.height * videoTrack.displayHeight / rotatedHeight),
+			]
+			: [videoTrack.displayWidth, videoTrack.displayHeight];
 		const originalAspectRatio = width / height;
 
 		// If width and height aren't defined together, deduce the missing value using the aspect ratio

--- a/src/mpeg-ts/mpeg-ts-demuxer.ts
+++ b/src/mpeg-ts/mpeg-ts-demuxer.ts
@@ -1497,6 +1497,14 @@ class MpegTsVideoTrackBacking extends MpegTsTrackBacking implements InputVideoTr
 		return this.elementaryStream.info.height;
 	}
 
+	getHSpacing() {
+		return 1;
+	}
+
+	getVSpacing() {
+		return 1;
+	}
+
 	getRotation(): Rotation {
 		return 0;
 	}


### PR DESCRIPTION
implements https://github.com/Vanilagy/mediabunny/issues/309

I added new fields:
```
hSpacing
vSpacing
```

for most containers they're just 1:1, but for mov/mp4 they're extracted from PASP box if present
I also passed these fields to the Sample and applied in CanvasSink - since the crop is defined in coded pixels space

I did run some tests using media player example using:
```
npm run docs:build
npm run docs:preview
```

and it works great
before:
<img width="2060" height="1308" alt="image" src="https://github.com/user-attachments/assets/0a0bcdec-2dea-4a13-b325-64953eb7031c" />

after:
<img width="1959" height="883" alt="image" src="https://github.com/user-attachments/assets/96cf8919-e6f3-4026-9394-f89374d2862d" />
