### PR TITLE
Handle cross-realm ArrayBuffers in buffer source validation

### DIFF
--- a/src/adts/adts-demuxer.ts
+++ b/src/adts/adts-demuxer.ts
@@ -23,6 +23,7 @@ import {
 	AsyncMutex,
 	binarySearchExact,
 	binarySearchLessOrEqual,
+	isPromiseLike,
 	UNDETERMINED_LANGUAGE,
 } from '../misc';
 import { EncodedPacket, PLACEHOLDER_DATA } from '../packet';
@@ -84,7 +85,7 @@ export class AdtsDemuxer extends Demuxer {
 			// Skip all ID3v2 tags at the start of the file
 			while (true) {
 				let slice = this.reader.requestSlice(this.lastLoadedPos, ID3_V2_HEADER_SIZE);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 
 				if (!slice) {
 					this.lastSampleLoaded = true;
@@ -105,7 +106,7 @@ export class AdtsDemuxer extends Demuxer {
 			MIN_ADTS_FRAME_HEADER_SIZE,
 			MAX_ADTS_FRAME_HEADER_SIZE,
 		);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) {
 			this.lastSampleLoaded = true;
 			return;
@@ -176,7 +177,7 @@ export class AdtsDemuxer extends Demuxer {
 
 			while (true) {
 				let headerSlice = this.reader.requestSlice(currentPos, ID3_V2_HEADER_SIZE);
-				if (headerSlice instanceof Promise) headerSlice = await headerSlice;
+				if (isPromiseLike(headerSlice)) headerSlice = await headerSlice;
 				if (!headerSlice) break;
 
 				const id3V2Header = readId3V2Header(headerSlice);
@@ -185,7 +186,7 @@ export class AdtsDemuxer extends Demuxer {
 				}
 
 				let contentSlice = this.reader.requestSlice(headerSlice.filePos, id3V2Header.size);
-				if (contentSlice instanceof Promise) contentSlice = await contentSlice;
+				if (isPromiseLike(contentSlice)) contentSlice = await contentSlice;
 				if (!contentSlice) break;
 
 				parseId3V2Tag(contentSlice, id3V2Header, this.metadataTags);
@@ -292,7 +293,7 @@ class AdtsAudioTrackBacking implements InputAudioTrackBacking {
 			data = PLACEHOLDER_DATA;
 		} else {
 			let slice = this.demuxer.reader.requestSlice(rawSample.dataStart, rawSample.dataSize);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 
 			if (!slice) {
 				return null; // Data didn't fit into the rest of the file

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -40,6 +40,7 @@ import {
 	assert,
 	clamp,
 	isIso639Dash2LanguageCode,
+	isPromiseLike,
 	MaybePromise,
 	normalizeRotation,
 	promiseWithResolvers,
@@ -1292,7 +1293,7 @@ export class Conversion {
 			finalSamples = [sample];
 		} else {
 			let processed = trackOptions.process(sample);
-			if (processed instanceof Promise) processed = await processed;
+			if (isPromiseLike(processed)) processed = await processed;
 
 			if (!Array.isArray(processed)) {
 				processed = processed === null ? [] : [processed];
@@ -1540,7 +1541,7 @@ export class Conversion {
 			finalSamples = [sample];
 		} else {
 			let processed = trackOptions.process(sample);
-			if (processed instanceof Promise) processed = await processed;
+			if (isPromiseLike(processed)) processed = await processed;
 
 			if (!Array.isArray(processed)) {
 				processed = processed === null ? [] : [processed];

--- a/src/flac/flac-demuxer.ts
+++ b/src/flac/flac-demuxer.ts
@@ -15,6 +15,7 @@ import {
 	assert,
 	AsyncMutex,
 	binarySearchLessOrEqual,
+	isPromiseLike,
 	textDecoder,
 	UNDETERMINED_LANGUAGE,
 } from '../misc';
@@ -116,7 +117,7 @@ export class FlacDemuxer extends Demuxer {
 				|| currentPos < this.reader.fileSize
 			) {
 				let sizeSlice = this.reader.requestSlice(currentPos, 4);
-				if (sizeSlice instanceof Promise) sizeSlice = await sizeSlice;
+				if (isPromiseLike(sizeSlice)) sizeSlice = await sizeSlice;
 				currentPos += 4;
 
 				if (sizeSlice === null) {
@@ -140,7 +141,7 @@ export class FlacDemuxer extends Demuxer {
 							currentPos,
 							size,
 						);
-						if (streamInfoBlock instanceof Promise) streamInfoBlock = await streamInfoBlock;
+						if (isPromiseLike(streamInfoBlock)) streamInfoBlock = await streamInfoBlock;
 
 						assert(streamInfoBlock);
 						if (streamInfoBlock === null) {
@@ -199,7 +200,7 @@ export class FlacDemuxer extends Demuxer {
 							currentPos,
 							size,
 						);
-						if (vorbisCommentBlock instanceof Promise) vorbisCommentBlock = await vorbisCommentBlock;
+						if (isPromiseLike(vorbisCommentBlock)) vorbisCommentBlock = await vorbisCommentBlock;
 
 						assert(vorbisCommentBlock);
 
@@ -217,7 +218,7 @@ export class FlacDemuxer extends Demuxer {
 							currentPos,
 							size,
 						);
-						if (pictureBlock instanceof Promise) pictureBlock = await pictureBlock;
+						if (isPromiseLike(pictureBlock)) pictureBlock = await pictureBlock;
 
 						assert(pictureBlock);
 						const pictureType = readU32Be(pictureBlock);
@@ -696,7 +697,7 @@ class FlacAudioTrackBacking implements InputAudioTrackBacking {
 				rawSample.byteOffset,
 				rawSample.byteSize,
 			);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 
 			if (!slice) {
 				return null; // Data didn't fit into the rest of the file

--- a/src/input-format.ts
+++ b/src/input-format.ts
@@ -29,6 +29,7 @@ import { WaveDemuxer } from './wave/wave-demuxer';
 import { MAX_ADTS_FRAME_HEADER_SIZE, MIN_ADTS_FRAME_HEADER_SIZE, readAdtsFrameHeader } from './adts/adts-reader';
 import { AdtsDemuxer } from './adts/adts-demuxer';
 import { readAscii, readBytes, readU32Be } from './reader';
+import { isPromiseLike } from './misc';
 import { FlacDemuxer } from './flac/flac-demuxer';
 import { MpegTsDemuxer } from './mpeg-ts/mpeg-ts-demuxer';
 import { TS_PACKET_SIZE } from './mpeg-ts/mpeg-ts-misc';
@@ -60,7 +61,7 @@ export abstract class IsobmffInputFormat extends InputFormat {
 	/** @internal */
 	protected async _getMajorBrand(input: Input) {
 		let slice = input._reader.requestSlice(0, 12);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return null;
 
 		slice.skip(4);
@@ -139,7 +140,7 @@ export class MatroskaInputFormat extends InputFormat {
 	/** @internal */
 	protected async isSupportedEBMLOfDocType(input: Input, desiredDocType: string) {
 		let headerSlice = input._reader.requestSlice(0, MAX_HEADER_SIZE);
-		if (headerSlice instanceof Promise) headerSlice = await headerSlice;
+		if (isPromiseLike(headerSlice)) headerSlice = await headerSlice;
 		if (!headerSlice) return false;
 
 		const varIntSize = readVarIntSize(headerSlice);
@@ -162,7 +163,7 @@ export class MatroskaInputFormat extends InputFormat {
 		}
 
 		let dataSlice = input._reader.requestSlice(headerSlice.filePos, dataSize);
-		if (dataSlice instanceof Promise) dataSlice = await dataSlice;
+		if (isPromiseLike(dataSlice)) dataSlice = await dataSlice;
 		if (!dataSlice) return false;
 
 		const startPos = headerSlice.filePos;
@@ -265,7 +266,7 @@ export class Mp3InputFormat extends InputFormat {
 
 		while (true) {
 			let slice = input._reader.requestSlice(currentPos, ID3_V2_HEADER_SIZE);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			if (!slice) break;
 
 			const id3V2Header = readId3V2Header(slice);
@@ -285,7 +286,7 @@ export class Mp3InputFormat extends InputFormat {
 		const xingOffset = getXingOffset(firstHeader.mpegVersionId, firstHeader.channel);
 
 		let slice = input._reader.requestSlice(firstResult.startPos + xingOffset, 4);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return false;
 
 		const word = readU32Be(slice);
@@ -342,7 +343,7 @@ export class WaveInputFormat extends InputFormat {
 	/** @internal */
 	async _canReadInput(input: Input) {
 		let slice = input._reader.requestSlice(0, 12);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return false;
 
 		const riffType = readAscii(slice, 4);
@@ -382,7 +383,7 @@ export class OggInputFormat extends InputFormat {
 	/** @internal */
 	async _canReadInput(input: Input) {
 		let slice = input._reader.requestSlice(0, 4);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return false;
 
 		return readAscii(slice, 4) === 'OggS';
@@ -413,7 +414,7 @@ export class FlacInputFormat extends InputFormat {
 	/** @internal */
 	async _canReadInput(input: Input) {
 		let slice = input._reader.requestSlice(0, 4);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return false;
 
 		return readAscii(slice, 4) === 'fLaC';
@@ -448,7 +449,7 @@ export class AdtsInputFormat extends InputFormat {
 
 		while (true) {
 			let slice = input._reader.requestSlice(currentPos, ID3_V2_HEADER_SIZE);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			if (!slice) break;
 
 			const id3V2Header = readId3V2Header(slice);
@@ -464,7 +465,7 @@ export class AdtsInputFormat extends InputFormat {
 			MIN_ADTS_FRAME_HEADER_SIZE,
 			MAX_ADTS_FRAME_HEADER_SIZE,
 		);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return false;
 
 		const firstHeader = readAdtsFrameHeader(slice);
@@ -479,7 +480,7 @@ export class AdtsInputFormat extends InputFormat {
 			MIN_ADTS_FRAME_HEADER_SIZE,
 			MAX_ADTS_FRAME_HEADER_SIZE,
 		);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return false;
 
 		const secondHeader = readAdtsFrameHeader(slice);
@@ -519,7 +520,7 @@ export class MpegTsInputFormat extends InputFormat {
 	async _canReadInput(input: Input) {
 		const lengthToCheck = TS_PACKET_SIZE + 16 + 1;
 		let slice = input._reader.requestSlice(0, lengthToCheck);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return false;
 
 		const bytes = readBytes(slice, lengthToCheck);

--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -50,6 +50,7 @@ import {
 	COLOR_PRIMARIES_MAP_INVERSE,
 	findLastIndex,
 	isIso639Dash2LanguageCode,
+	isPromiseLike,
 	last,
 	MATRIX_COEFFICIENTS_MAP_INVERSE,
 	normalizeRotation,
@@ -301,7 +302,7 @@ export class IsobmffDemuxer extends Demuxer {
 			let currentPos = 0;
 			while (true) {
 				let slice = this.reader.requestSliceRange(currentPos, MIN_BOX_HEADER_SIZE, MAX_BOX_HEADER_SIZE);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 				if (!slice) break;
 
 				const startPos = currentPos;
@@ -317,7 +318,7 @@ export class IsobmffDemuxer extends Demuxer {
 					// Found moov, load it
 
 					let moovSlice = this.reader.requestSlice(slice.filePos, boxInfo.contentSize);
-					if (moovSlice instanceof Promise) moovSlice = await moovSlice;
+					if (isPromiseLike(moovSlice)) moovSlice = await moovSlice;
 					if (!moovSlice) break;
 
 					this.moovSlice = moovSlice;
@@ -343,7 +344,7 @@ export class IsobmffDemuxer extends Demuxer {
 			if (this.isFragmented && this.reader.fileSize !== null) {
 				// The last 4 bytes may contain the size of the mfra box at the end of the file
 				let lastWordSlice = this.reader.requestSlice(this.reader.fileSize - 4, 4);
-				if (lastWordSlice instanceof Promise) lastWordSlice = await lastWordSlice;
+				if (isPromiseLike(lastWordSlice)) lastWordSlice = await lastWordSlice;
 				assert(lastWordSlice);
 
 				const lastWord = readU32Be(lastWordSlice);
@@ -355,7 +356,7 @@ export class IsobmffDemuxer extends Demuxer {
 						MIN_BOX_HEADER_SIZE,
 						MAX_BOX_HEADER_SIZE,
 					);
-					if (mfraHeaderSlice instanceof Promise) mfraHeaderSlice = await mfraHeaderSlice;
+					if (isPromiseLike(mfraHeaderSlice)) mfraHeaderSlice = await mfraHeaderSlice;
 
 					if (mfraHeaderSlice) {
 						const boxInfo = readBoxHeader(mfraHeaderSlice);
@@ -363,7 +364,7 @@ export class IsobmffDemuxer extends Demuxer {
 						if (boxInfo && boxInfo.name === 'mfra') {
 							// We found the mfra box, allowing for much better random access. Let's parse it.
 							let mfraSlice = this.reader.requestSlice(mfraHeaderSlice.filePos, boxInfo.contentSize);
-							if (mfraSlice instanceof Promise) mfraSlice = await mfraSlice;
+							if (isPromiseLike(mfraSlice)) mfraSlice = await mfraSlice;
 
 							if (mfraSlice) {
 								this.readContiguousBoxes(mfraSlice);
@@ -524,14 +525,14 @@ export class IsobmffDemuxer extends Demuxer {
 		}
 
 		let headerSlice = this.reader.requestSliceRange(startPos, MIN_BOX_HEADER_SIZE, MAX_BOX_HEADER_SIZE);
-		if (headerSlice instanceof Promise) headerSlice = await headerSlice;
+		if (isPromiseLike(headerSlice)) headerSlice = await headerSlice;
 		assert(headerSlice);
 
 		const moofBoxInfo = readBoxHeader(headerSlice);
 		assert(moofBoxInfo?.name === 'moof');
 
 		let entireSlice = this.reader.requestSlice(startPos, moofBoxInfo.totalSize);
-		if (entireSlice instanceof Promise) entireSlice = await entireSlice;
+		if (isPromiseLike(entireSlice)) entireSlice = await entireSlice;
 		assert(entireSlice);
 
 		this.traverseBox(entireSlice);
@@ -2693,7 +2694,7 @@ abstract class IsobmffTrackBacking implements InputTrackBacking {
 				sampleInfo.sampleOffset,
 				sampleInfo.sampleSize,
 			);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			assert(slice);
 
 			data = readBytes(slice, sampleInfo.sampleSize);
@@ -2733,7 +2734,7 @@ abstract class IsobmffTrackBacking implements InputTrackBacking {
 				fragmentSample.byteOffset,
 				fragmentSample.byteSize,
 			);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			assert(slice);
 
 			data = readBytes(slice, fragmentSample.byteSize);
@@ -2837,7 +2838,7 @@ abstract class IsobmffTrackBacking implements InputTrackBacking {
 
 			// Load the header
 			let slice = demuxer.reader.requestSliceRange(currentPos, MIN_BOX_HEADER_SIZE, MAX_BOX_HEADER_SIZE);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			if (!slice) break;
 
 			const boxStartPos = currentPos;

--- a/src/matroska/ebml.ts
+++ b/src/matroska/ebml.ts
@@ -7,7 +7,7 @@
  */
 
 import { MediaCodec } from '../codec';
-import { assert, assertNever, textDecoder, textEncoder } from '../misc';
+import { assert, assertNever, isPromiseLike, textDecoder, textEncoder } from '../misc';
 import { FileSlice, readBytes, Reader, readF32Be, readF64Be, readU8 } from '../reader';
 import { Writer } from '../writer';
 
@@ -688,7 +688,7 @@ export const searchForNextElementId = async (
 
 	while (until === null || currentPos < until) {
 		let slice = reader.requestSliceRange(currentPos, MIN_HEADER_SIZE, MAX_HEADER_SIZE);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) break;
 
 		const elementHeader = readElementHeader(slice);
@@ -716,7 +716,7 @@ export const resync = async (reader: Reader, startPos: number, ids: EBMLId[], un
 
 	while (currentPos < until) {
 		let slice = reader.requestSliceRange(currentPos, 0, Math.min(CHUNK_SIZE, until - currentPos));
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) break;
 		if (slice.length < MAX_VAR_INT_SIZE) break;
 

--- a/src/matroska/matroska-demuxer.ts
+++ b/src/matroska/matroska-demuxer.ts
@@ -39,6 +39,7 @@ import {
 	COLOR_PRIMARIES_MAP_INVERSE,
 	findLastIndex,
 	isIso639Dash2LanguageCode,
+	isPromiseLike,
 	last,
 	MATRIX_COEFFICIENTS_MAP_INVERSE,
 	normalizeRotation,
@@ -329,7 +330,7 @@ export class MatroskaDemuxer extends Demuxer {
 			// Loop over all top-level elements in the file
 			while (true) {
 				let slice = this.reader.requestSliceRange(currentPos, MIN_HEADER_SIZE, MAX_HEADER_SIZE);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 				if (!slice) break;
 
 				const header = readElementHeader(slice);
@@ -345,7 +346,7 @@ export class MatroskaDemuxer extends Demuxer {
 					assertDefinedSize(size);
 
 					let slice = this.reader.requestSlice(dataStartPos, size);
-					if (slice instanceof Promise) slice = await slice;
+					if (isPromiseLike(slice)) slice = await slice;
 					if (!slice) break;
 
 					this.readContiguousElements(slice);
@@ -428,7 +429,7 @@ export class MatroskaDemuxer extends Demuxer {
 
 		while (this.currentSegment.elementEndPos === null || currentPos < this.currentSegment.elementEndPos) {
 			let slice = this.reader.requestSliceRange(currentPos, MIN_HEADER_SIZE, MAX_HEADER_SIZE);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			if (!slice) break;
 
 			const elementStartPos = currentPos;
@@ -463,7 +464,7 @@ export class MatroskaDemuxer extends Demuxer {
 				assertDefinedSize(size);
 
 				let slice = this.reader.requestSlice(dataStartPos, size);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 
 				if (slice) {
 					this.readContiguousElements(slice);
@@ -479,7 +480,7 @@ export class MatroskaDemuxer extends Demuxer {
 				assertDefinedSize(size);
 
 				let slice = this.reader.requestSlice(dataStartPos, size);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 
 				if (slice) {
 					this.readContiguousElements(slice);
@@ -514,7 +515,7 @@ export class MatroskaDemuxer extends Demuxer {
 					MIN_HEADER_SIZE,
 					MAX_HEADER_SIZE,
 				);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 				if (!slice) continue;
 
 				const header = readElementHeader(slice);
@@ -528,7 +529,7 @@ export class MatroskaDemuxer extends Demuxer {
 				this.currentSegment[target.flag] = true;
 
 				let dataSlice = this.reader.requestSlice(slice.filePos, size);
-				if (dataSlice instanceof Promise) dataSlice = await dataSlice;
+				if (isPromiseLike(dataSlice)) dataSlice = await dataSlice;
 				if (!dataSlice) continue;
 
 				this.readContiguousElements(dataSlice);
@@ -606,7 +607,7 @@ export class MatroskaDemuxer extends Demuxer {
 		}
 
 		let headerSlice = this.reader.requestSliceRange(startPos, MIN_HEADER_SIZE, MAX_HEADER_SIZE);
-		if (headerSlice instanceof Promise) headerSlice = await headerSlice;
+		if (isPromiseLike(headerSlice)) headerSlice = await headerSlice;
 		assert(headerSlice);
 
 		const elementStartPos = startPos;
@@ -635,7 +636,7 @@ export class MatroskaDemuxer extends Demuxer {
 
 		// Load the entire cluster
 		let dataSlice = this.reader.requestSlice(dataStartPos, size);
-		if (dataSlice instanceof Promise) dataSlice = await dataSlice;
+		if (isPromiseLike(dataSlice)) dataSlice = await dataSlice;
 
 		const cluster: Cluster = {
 			segment,
@@ -891,7 +892,7 @@ export class MatroskaDemuxer extends Demuxer {
 				MIN_HEADER_SIZE,
 				MAX_HEADER_SIZE,
 			);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			if (!slice) continue;
 
 			const header = readElementHeader(slice);
@@ -904,7 +905,7 @@ export class MatroskaDemuxer extends Demuxer {
 			this.currentSegment = segment;
 
 			let dataSlice = this.reader.requestSlice(slice.filePos, size);
-			if (dataSlice instanceof Promise) dataSlice = await dataSlice;
+			if (isPromiseLike(dataSlice)) dataSlice = await dataSlice;
 			if (dataSlice) {
 				this.readContiguousElements(dataSlice);
 			}
@@ -2261,7 +2262,7 @@ abstract class MatroskaTrackBacking implements InputTrackBacking {
 
 			// Load the header
 			let slice = demuxer.reader.requestSliceRange(currentPos, MIN_HEADER_SIZE, MAX_HEADER_SIZE);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			if (!slice) break;
 
 			const elementStartPos = currentPos;
@@ -2332,7 +2333,7 @@ abstract class MatroskaTrackBacking implements InputTrackBacking {
 				// the first segment.
 
 				let slice = demuxer.reader.requestSliceRange(endPos, MIN_HEADER_SIZE, MAX_HEADER_SIZE);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 				if (!slice) break;
 
 				const elementId = readElementId(slice);

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { isUint8Array } from './misc';
+
 /**
  * Represents descriptive (non-technical) metadata about a media file, such as title, author, date, cover art, or other
  * attached files. Common tags are normalized by Mediabunny into a uniform format, while the `raw` field can be used to
@@ -114,7 +116,7 @@ export class RichImageData {
 		/** An RFC 6838 MIME type (e.g. image/jpeg, image/png, etc.) */
 		public mimeType: string,
 	) {
-		if (!(data instanceof Uint8Array)) {
+		if (!isUint8Array(data)) {
 			throw new TypeError('data must be a Uint8Array.');
 		}
 		if (typeof mimeType !== 'string') {
@@ -141,7 +143,7 @@ export class AttachedFile {
 		/** A description of the file. */
 		public description?: string,
 	) {
-		if (!(data instanceof Uint8Array)) {
+		if (!isUint8Array(data)) {
 			throw new TypeError('data must be a Uint8Array.');
 		}
 		if (mimeType !== undefined && typeof mimeType !== 'string') {
@@ -210,7 +212,7 @@ export const validateMetadataTags = (tags: MetadataTags) => {
 			if (!image || typeof image !== 'object') {
 				throw new TypeError('Each image in tags.images must be an object.');
 			}
-			if (!(image.data instanceof Uint8Array)) {
+			if (!isUint8Array(image.data)) {
 				throw new TypeError('Each image.data must be a Uint8Array.');
 			}
 			if (typeof image.mimeType !== 'string') {
@@ -233,7 +235,7 @@ export const validateMetadataTags = (tags: MetadataTags) => {
 			if (
 				value !== null
 				&& typeof value !== 'string'
-				&& !(value instanceof Uint8Array)
+				&& !isUint8Array(value)
 				&& !(value instanceof RichImageData)
 				&& !(value instanceof AttachedFile)
 			) {

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -78,9 +78,10 @@ export const writeBits = (bytes: Uint8Array, start: number, end: number, value: 
 };
 
 export const toUint8Array = (source: AllowSharedBufferSource): Uint8Array => {
-	if (source.constructor === Uint8Array) { // We want a true Uint8Array, not something that extends it like Buffer
-		return source;
-	} else if (ArrayBuffer.isView(source)) {
+	if (ArrayBuffer.isView(source)) {
+		if (isUint8Array(source)) {
+			return source;
+		}
 		return new Uint8Array(source.buffer, source.byteOffset, source.byteLength);
 	} else {
 		return new Uint8Array(source);
@@ -88,9 +89,10 @@ export const toUint8Array = (source: AllowSharedBufferSource): Uint8Array => {
 };
 
 export const toDataView = (source: AllowSharedBufferSource): DataView => {
-	if (source.constructor === DataView) {
-		return source;
-	} else if (ArrayBuffer.isView(source)) {
+	if (ArrayBuffer.isView(source)) {
+		if (isDataView(source)) {
+			return source;
+		}
 		return new DataView(source.buffer, source.byteOffset, source.byteLength);
 	} else {
 		return new DataView(source);
@@ -161,15 +163,82 @@ export const colorSpaceIsComplete = (
 	);
 };
 
-const getObjectTypeTag = (x: unknown) => Object.prototype.toString.call(x);
+const getObjectTypeTag = (x: unknown) => {
+	try {
+		return Object.prototype.toString.call(x);
+	} catch {
+		return '';
+	}
+};
+
+const safeInstanceOf = <T extends abstract new (...args: never[]) => unknown>(
+	x: unknown,
+	constructor: T | undefined,
+) => {
+	if (!constructor) {
+		return false;
+	}
+
+	try {
+		return x instanceof constructor;
+	} catch {
+		return false;
+	}
+};
 
 export const isArrayBuffer = (x: unknown): x is ArrayBuffer => {
-	return x instanceof ArrayBuffer || getObjectTypeTag(x) === '[object ArrayBuffer]';
+	return safeInstanceOf(x, ArrayBuffer) || getObjectTypeTag(x) === '[object ArrayBuffer]';
 };
 
 export const isSharedArrayBuffer = (x: unknown): x is SharedArrayBuffer => {
-	return typeof SharedArrayBuffer !== 'undefined'
-		&& (x instanceof SharedArrayBuffer || getObjectTypeTag(x) === '[object SharedArrayBuffer]');
+	return safeInstanceOf(x, typeof SharedArrayBuffer !== 'undefined' ? SharedArrayBuffer : undefined)
+		|| getObjectTypeTag(x) === '[object SharedArrayBuffer]';
+};
+
+export const isUint8Array = (x: unknown): x is Uint8Array => {
+	return safeInstanceOf(x, Uint8Array) || getObjectTypeTag(x) === '[object Uint8Array]';
+};
+
+export const isDataView = (x: unknown): x is DataView => {
+	return safeInstanceOf(x, DataView) || getObjectTypeTag(x) === '[object DataView]';
+};
+
+export const isBlob = (x: unknown): x is Blob => {
+	const objectTypeTag = getObjectTypeTag(x);
+	return safeInstanceOf(x, typeof Blob !== 'undefined' ? Blob : undefined)
+		|| objectTypeTag === '[object Blob]'
+		|| objectTypeTag === '[object File]';
+};
+
+export const isPromiseLike = <T = unknown>(x: unknown): x is PromiseLike<T> => {
+	if ((typeof x !== 'object' && typeof x !== 'function') || x === null) {
+		return false;
+	}
+
+	if (getObjectTypeTag(x) === '[object Promise]') {
+		return true;
+	}
+
+	try {
+		return 'then' in x && typeof x.then === 'function';
+	} catch {
+		return false;
+	}
+};
+
+export const isReadableStream = (x: unknown): x is ReadableStream<Uint8Array> => {
+	return safeInstanceOf(x, typeof ReadableStream !== 'undefined' ? ReadableStream : undefined)
+		|| getObjectTypeTag(x) === '[object ReadableStream]';
+};
+
+export const awaitPromiseLike = <T>(x: PromiseLike<T>) => {
+	return new Promise<T>((resolve, reject) => {
+		try {
+			x.then(resolve, reject);
+		} catch (error) {
+			reject(error instanceof Error ? error : new Error(String(error)));
+		}
+	});
 };
 
 export const isAllowSharedBufferSource = (x: unknown) => {

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -161,10 +161,21 @@ export const colorSpaceIsComplete = (
 	);
 };
 
+const getObjectTypeTag = (x: unknown) => Object.prototype.toString.call(x);
+
+export const isArrayBuffer = (x: unknown): x is ArrayBuffer => {
+	return x instanceof ArrayBuffer || getObjectTypeTag(x) === '[object ArrayBuffer]';
+};
+
+export const isSharedArrayBuffer = (x: unknown): x is SharedArrayBuffer => {
+	return typeof SharedArrayBuffer !== 'undefined'
+		&& (x instanceof SharedArrayBuffer || getObjectTypeTag(x) === '[object SharedArrayBuffer]');
+};
+
 export const isAllowSharedBufferSource = (x: unknown) => {
 	return (
-		x instanceof ArrayBuffer
-		|| (typeof SharedArrayBuffer !== 'undefined' && x instanceof SharedArrayBuffer)
+		isArrayBuffer(x)
+		|| isSharedArrayBuffer(x)
 		|| ArrayBuffer.isView(x)
 	);
 };

--- a/src/mp3/mp3-demuxer.ts
+++ b/src/mp3/mp3-demuxer.ts
@@ -12,7 +12,14 @@ import { Input } from '../input';
 import { InputAudioTrack, InputAudioTrackBacking } from '../input-track';
 import { DEFAULT_TRACK_DISPOSITION, MetadataTags } from '../metadata';
 import { PacketRetrievalOptions } from '../media-sink';
-import { assert, AsyncMutex, binarySearchExact, binarySearchLessOrEqual, UNDETERMINED_LANGUAGE } from '../misc';
+import {
+	assert,
+	AsyncMutex,
+	binarySearchExact,
+	binarySearchLessOrEqual,
+	isPromiseLike,
+	UNDETERMINED_LANGUAGE,
+} from '../misc';
 import { EncodedPacket, PLACEHOLDER_DATA } from '../packet';
 import { Mp3FrameHeader, getXingOffset, INFO, XING } from '../../shared/mp3-misc';
 import {
@@ -73,7 +80,7 @@ export class Mp3Demuxer extends Demuxer {
 			// Let's skip all ID3v2 tags at the start of the file
 			while (true) {
 				let slice = this.reader.requestSlice(this.lastLoadedPos, ID3_V2_HEADER_SIZE);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 
 				if (!slice) {
 					this.lastSampleLoaded = true;
@@ -102,7 +109,7 @@ export class Mp3Demuxer extends Demuxer {
 		const xingOffset = getXingOffset(header.mpegVersionId, header.channel);
 
 		let slice = this.reader.requestSlice(result.startPos + xingOffset, 4);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (slice) {
 			const word = readU32Be(slice);
 			const isXing = word === XING || word === INFO;
@@ -172,7 +179,7 @@ export class Mp3Demuxer extends Demuxer {
 
 			while (true) {
 				let headerSlice = this.reader.requestSlice(currentPos, ID3_V2_HEADER_SIZE);
-				if (headerSlice instanceof Promise) headerSlice = await headerSlice;
+				if (isPromiseLike(headerSlice)) headerSlice = await headerSlice;
 				if (!headerSlice) break;
 
 				const id3V2Header = readId3V2Header(headerSlice);
@@ -183,7 +190,7 @@ export class Mp3Demuxer extends Demuxer {
 				id3V2HeaderFound = true;
 
 				let contentSlice = this.reader.requestSlice(headerSlice.filePos, id3V2Header.size);
-				if (contentSlice instanceof Promise) contentSlice = await contentSlice;
+				if (isPromiseLike(contentSlice)) contentSlice = await contentSlice;
 				if (!contentSlice) break;
 
 				parseId3V2Tag(contentSlice, id3V2Header, this.metadataTags);
@@ -194,7 +201,7 @@ export class Mp3Demuxer extends Demuxer {
 			if (!id3V2HeaderFound && this.reader.fileSize !== null && this.reader.fileSize >= ID3_V1_TAG_SIZE) {
 				// Try reading an ID3v1 tag at the end of the file
 				let slice = this.reader.requestSlice(this.reader.fileSize - ID3_V1_TAG_SIZE, ID3_V1_TAG_SIZE);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 				assert(slice);
 
 				const tag = readAscii(slice, 3);
@@ -292,7 +299,7 @@ class Mp3AudioTrackBacking implements InputAudioTrackBacking {
 			data = PLACEHOLDER_DATA;
 		} else {
 			let slice = this.demuxer.reader.requestSlice(rawSample.dataStart, rawSample.dataSize);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 
 			if (!slice) {
 				return null; // Data didn't fit into the rest of the file

--- a/src/mp3/mp3-reader.ts
+++ b/src/mp3/mp3-reader.ts
@@ -7,6 +7,7 @@
  */
 
 import { FRAME_HEADER_SIZE, Mp3FrameHeader, readMp3FrameHeader } from '../../shared/mp3-misc';
+import { isPromiseLike } from '../misc';
 import { Reader, readU32Be } from '../reader';
 
 export const readNextMp3FrameHeader = async (reader: Reader, startPos: number, until: number | null): Promise<{
@@ -17,7 +18,7 @@ export const readNextMp3FrameHeader = async (reader: Reader, startPos: number, u
 
 	while (until === null || currentPos < until) {
 		let slice = reader.requestSlice(currentPos, FRAME_HEADER_SIZE);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) break;
 
 		const word = readU32Be(slice);

--- a/src/mpeg-ts/mpeg-ts-demuxer.ts
+++ b/src/mpeg-ts/mpeg-ts-demuxer.ts
@@ -56,6 +56,7 @@ import {
 	COLOR_PRIMARIES_MAP_INVERSE,
 	findLastIndex,
 	floorToMultiple,
+	isPromiseLike,
 	last,
 	MATRIX_COEFFICIENTS_MAP_INVERSE,
 	Rotation,
@@ -148,7 +149,7 @@ export class MpegTsDemuxer extends Demuxer {
 		return this.metadataPromise ??= (async () => {
 			const lengthToCheck = TS_PACKET_SIZE + 16 + 1;
 			let startingSlice = this.reader.requestSlice(0, lengthToCheck);
-			if (startingSlice instanceof Promise) startingSlice = await startingSlice;
+			if (isPromiseLike(startingSlice)) startingSlice = await startingSlice;
 			assert(startingSlice);
 
 			const startingBytes = readBytes(startingSlice, lengthToCheck);
@@ -745,7 +746,7 @@ export class MpegTsDemuxer extends Demuxer {
 
 	async readPacketHeader(pos: number): Promise<TsPacketHeader | null> {
 		let slice = this.reader.requestSlice(pos, 4);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 
 		if (!slice) {
 			return null;
@@ -781,7 +782,7 @@ export class MpegTsDemuxer extends Demuxer {
 	async readPacket(pos: number): Promise<TsPacket | null> {
 		// Code in here is duplicated from readPacketHeader for performance reasons
 		let slice = this.reader.requestSlice(pos, TS_PACKET_SIZE);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 
 		if (!slice) {
 			return null;
@@ -1664,7 +1665,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 
 		while (true) {
 			let remaining = context.ensureBuffered(CHUNK_SIZE);
-			if (remaining instanceof Promise) remaining = await remaining;
+			if (isPromiseLike(remaining)) remaining = await remaining;
 
 			if (remaining === 0) {
 				break;
@@ -1763,7 +1764,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 
 		while (true) {
 			let remaining = context.ensureBuffered(CHUNK_SIZE);
-			if (remaining instanceof Promise) remaining = await remaining;
+			if (isPromiseLike(remaining)) remaining = await remaining;
 
 			const startPos = context.currentPos;
 
@@ -1779,7 +1780,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 					const possibleHeaderStartPos = context.currentPos;
 
 					let remaining = context.ensureBuffered(MAX_ADTS_FRAME_HEADER_SIZE);
-					if (remaining instanceof Promise) remaining = await remaining;
+					if (isPromiseLike(remaining)) remaining = await remaining;
 
 					if (remaining < MAX_ADTS_FRAME_HEADER_SIZE) {
 						return;
@@ -1792,7 +1793,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 						context.seekTo(possibleHeaderStartPos);
 
 						let remaining = context.ensureBuffered(header.frameLength);
-						if (remaining instanceof Promise) remaining = await remaining;
+						if (isPromiseLike(remaining)) remaining = await remaining;
 
 						return context.supplyPacket(
 							remaining,
@@ -1810,7 +1811,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 					const possibleHeaderStartPos = context.currentPos;
 
 					let remaining = context.ensureBuffered(MP3_FRAME_HEADER_SIZE);
-					if (remaining instanceof Promise) remaining = await remaining;
+					if (isPromiseLike(remaining)) remaining = await remaining;
 
 					if (remaining < MP3_FRAME_HEADER_SIZE) {
 						return;
@@ -1824,7 +1825,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 						context.seekTo(possibleHeaderStartPos);
 
 						let remaining = context.ensureBuffered(result.header.totalSize);
-						if (remaining instanceof Promise) remaining = await remaining;
+						if (isPromiseLike(remaining)) remaining = await remaining;
 
 						const duration = result.header.audioSamplesInFrame * TIMESCALE
 							/ elementaryStream.info.sampleRate;
@@ -1842,7 +1843,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 
 					// Need at least 5 bytes for sync word + CRC + fscod/frmsizecod
 					let remaining = context.ensureBuffered(5);
-					if (remaining instanceof Promise) remaining = await remaining;
+					if (isPromiseLike(remaining)) remaining = await remaining;
 
 					if (remaining < 5) {
 						return;
@@ -1871,7 +1872,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 					context.seekTo(possibleSyncPos);
 
 					remaining = context.ensureBuffered(frameSize);
-					if (remaining instanceof Promise) remaining = await remaining;
+					if (isPromiseLike(remaining)) remaining = await remaining;
 
 					const duration = Math.round(
 						AC3_SAMPLES_PER_FRAME * TIMESCALE / elementaryStream.info.sampleRate,
@@ -1887,7 +1888,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 
 					// Need at least 5 bytes for E-AC-3 header parsing (sync word + frmsiz + fscod/numblkscod)
 					let remaining = context.ensureBuffered(5);
-					if (remaining instanceof Promise) remaining = await remaining;
+					if (isPromiseLike(remaining)) remaining = await remaining;
 
 					if (remaining < 5) {
 						return;
@@ -1909,7 +1910,7 @@ const markNextPacket = async (context: PacketReadingContext) => {
 					context.seekTo(possibleSyncPos);
 
 					remaining = context.ensureBuffered(frameSize);
-					if (remaining instanceof Promise) remaining = await remaining;
+					if (isPromiseLike(remaining)) remaining = await remaining;
 
 					// Duration = numblks * 256 samples per block
 					const samplesPerFrame = numblks * 256;

--- a/src/ogg/ogg-demuxer.ts
+++ b/src/ogg/ogg-demuxer.ts
@@ -18,6 +18,7 @@ import {
 	AsyncMutex,
 	binarySearchLessOrEqual,
 	findLast,
+	isPromiseLike,
 	last,
 	roundIfAlmostInteger,
 	toDataView,
@@ -72,7 +73,7 @@ export class OggDemuxer extends Demuxer {
 
 			while (true) {
 				let slice = this.reader.requestSliceRange(currentPos, MIN_PAGE_HEADER_SIZE, MAX_PAGE_HEADER_SIZE);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 				if (!slice) break;
 
 				const page = readPageHeader(slice);
@@ -274,7 +275,7 @@ export class OggDemuxer extends Demuxer {
 		while (true) {
 			// Load the entire page data
 			let pageSlice = this.reader.requestSlice(currentPage.dataStartPos, currentPage.dataSize);
-			if (pageSlice instanceof Promise) pageSlice = await pageSlice;
+			if (isPromiseLike(pageSlice)) pageSlice = await pageSlice;
 			assert(pageSlice);
 			const pageData = readBytes(pageSlice, currentPage.dataSize);
 
@@ -299,7 +300,7 @@ export class OggDemuxer extends Demuxer {
 			let currentPos = currentPage.headerStartPos + currentPage.totalSize;
 			while (true) {
 				let headerSlice = this.reader.requestSliceRange(currentPos, MIN_PAGE_HEADER_SIZE, MAX_PAGE_HEADER_SIZE);
-				if (headerSlice instanceof Promise) headerSlice = await headerSlice;
+				if (isPromiseLike(headerSlice)) headerSlice = await headerSlice;
 				if (!headerSlice) {
 					return null;
 				}
@@ -358,7 +359,7 @@ export class OggDemuxer extends Demuxer {
 		let currentPos = lastPacket.endPage.headerStartPos + lastPacket.endPage.totalSize;
 		while (true) {
 			let slice = this.reader.requestSliceRange(currentPos, MIN_PAGE_HEADER_SIZE, MAX_PAGE_HEADER_SIZE);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			if (!slice) {
 				return null;
 			}
@@ -638,7 +639,7 @@ class OggAudioTrackBacking implements InputAudioTrackBacking {
 				);
 
 				let searchSlice = this.demuxer.reader.requestSlice(searchStartPos, until - searchStartPos);
-				if (searchSlice instanceof Promise) searchSlice = await searchSlice;
+				if (isPromiseLike(searchSlice)) searchSlice = await searchSlice;
 				assert(searchSlice);
 
 				const found = findNextPageHeader(searchSlice, until);
@@ -652,7 +653,7 @@ class OggAudioTrackBacking implements InputAudioTrackBacking {
 					MIN_PAGE_HEADER_SIZE,
 					MAX_PAGE_HEADER_SIZE,
 				);
-				if (headerSlice instanceof Promise) headerSlice = await headerSlice;
+				if (isPromiseLike(headerSlice)) headerSlice = await headerSlice;
 				assert(headerSlice);
 
 				const page = readPageHeader(headerSlice);
@@ -665,7 +666,7 @@ class OggAudioTrackBacking implements InputAudioTrackBacking {
 					pageValid = true;
 				} else {
 					let pageSlice = this.demuxer.reader.requestSlice(page.headerStartPos, page.totalSize);
-					if (pageSlice instanceof Promise) pageSlice = await pageSlice;
+					if (isPromiseLike(pageSlice)) pageSlice = await pageSlice;
 					assert(pageSlice);
 
 					// Validate the page by checking checksum
@@ -739,7 +740,7 @@ class OggAudioTrackBacking implements InputAudioTrackBacking {
 
 			const nextPos = currentPage.headerStartPos + currentPage.totalSize;
 			let slice = this.demuxer.reader.requestSliceRange(nextPos, MIN_PAGE_HEADER_SIZE, MAX_PAGE_HEADER_SIZE);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			assert(slice);
 
 			const nextPage = readPageHeader(slice);

--- a/src/packet.ts
+++ b/src/packet.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { SECOND_TO_MICROSECOND_FACTOR } from './misc';
+import { isUint8Array, SECOND_TO_MICROSECOND_FACTOR } from './misc';
 
 export const PLACEHOLDER_DATA = /* #__PURE__ */ new Uint8Array(0);
 
@@ -90,7 +90,7 @@ export class EncodedPacket {
 			byteLength = data.byteLength;
 		}
 
-		if (!(data instanceof Uint8Array)) {
+		if (!isUint8Array(data)) {
 			throw new TypeError('data must be a Uint8Array.');
 		}
 		if (type !== 'key' && type !== 'delta') {
@@ -111,7 +111,7 @@ export class EncodedPacket {
 		if (sideData !== undefined && (typeof sideData !== 'object' || !sideData)) {
 			throw new TypeError('sideData, when provided, must be an object.');
 		}
-		if (sideData?.alpha !== undefined && !(sideData.alpha instanceof Uint8Array)) {
+		if (sideData?.alpha !== undefined && !isUint8Array(sideData.alpha)) {
 			throw new TypeError('sideData.alpha, when provided, must be a Uint8Array.');
 		}
 		if (
@@ -255,7 +255,7 @@ export class EncodedPacket {
 		if (options !== undefined && (typeof options !== 'object' || options === null)) {
 			throw new TypeError('options, when provided, must be an object.');
 		}
-		if (options?.data !== undefined && !(options.data instanceof Uint8Array)) {
+		if (options?.data !== undefined && !isUint8Array(options.data)) {
 			throw new TypeError('options.data, when provided, must be a Uint8Array.');
 		}
 		if (options?.type !== undefined && options.type !== 'key' && options.type !== 'delta') {

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -7,7 +7,7 @@
  */
 
 import { InputDisposedError } from './input';
-import { assert, clamp, getUint24, MaybePromise, toDataView } from './misc';
+import { assert, awaitPromiseLike, clamp, getUint24, isPromiseLike, MaybePromise, toDataView } from './misc';
 import { Source } from './source';
 
 export class Reader {
@@ -31,8 +31,8 @@ export class Reader {
 		const end = start + length;
 		const result = this.source._read(start, end);
 
-		if (result instanceof Promise) {
-			return result.then((x) => {
+		if (isPromiseLike(result)) {
+			return awaitPromiseLike(result).then((x) => {
 				if (!x) {
 					return null;
 				}
@@ -80,15 +80,15 @@ export class Reader {
 				};
 
 				const promisedFileSize = this.source._retrieveSize();
-				if (promisedFileSize instanceof Promise) {
-					return promisedFileSize.then(handleFileSize);
+				if (isPromiseLike(promisedFileSize)) {
+					return awaitPromiseLike(promisedFileSize).then(handleFileSize);
 				} else {
 					return handleFileSize(promisedFileSize);
 				}
 			};
 
-			if (promisedAttempt instanceof Promise) {
-				return promisedAttempt.then(handleAttempt);
+			if (isPromiseLike(promisedAttempt)) {
+				return awaitPromiseLike(promisedAttempt).then(handleAttempt);
 			} else {
 				return handleAttempt(promisedAttempt);
 			}

--- a/src/sample.ts
+++ b/src/sample.ts
@@ -11,6 +11,7 @@ import {
 	clamp,
 	COLOR_PRIMARIES_MAP,
 	isAllowSharedBufferSource,
+	isArrayBuffer,
 	MATRIX_COEFFICIENTS_MAP,
 	Rotation,
 	SECOND_TO_MICROSECOND_FACTOR,
@@ -274,11 +275,7 @@ export class VideoSample implements Disposable {
 		data: VideoFrame | CanvasImageSource | AllowSharedBufferSource,
 		init?: VideoSampleInit,
 	) {
-		if (
-			data instanceof ArrayBuffer
-			|| (typeof SharedArrayBuffer !== 'undefined' && data instanceof SharedArrayBuffer)
-			|| ArrayBuffer.isView(data)
-		) {
+		if (isAllowSharedBufferSource(data)) {
 			if (!init || typeof init !== 'object') {
 				throw new TypeError('init must be an object.');
 			}
@@ -1450,14 +1447,10 @@ export class AudioSample implements Disposable {
 			this.timestamp = init.timestamp;
 			this.duration = numberOfFrames / init.sampleRate;
 
-			let dataBuffer: Uint8Array;
-			if (init.data instanceof ArrayBuffer) {
-				dataBuffer = new Uint8Array(init.data);
-			} else if (ArrayBuffer.isView(init.data)) {
-				dataBuffer = new Uint8Array(init.data.buffer, init.data.byteOffset, init.data.byteLength);
-			} else {
+			if (!isAllowSharedBufferSource(init.data)) {
 				throw new TypeError('Invalid AudioDataInit: data is not a BufferSource.');
 			}
+			const dataBuffer = toUint8Array(init.data);
 
 			const expectedSize
                 = this.numberOfFrames * this.numberOfChannels * getBytesPerSample(this.format);
@@ -1739,7 +1732,7 @@ export class AudioSample implements Disposable {
 				numberOfFrames: this.numberOfFrames,
 				numberOfChannels: this.numberOfChannels,
 				timestamp: this.microsecondTimestamp,
-				data: this._data.buffer instanceof ArrayBuffer
+				data: isArrayBuffer(this._data.buffer)
 					? this._data.buffer
 					: this._data.slice(), // In the case of SharedArrayBuffer, convert to ArrayBuffer
 			});

--- a/src/source.ts
+++ b/src/source.ts
@@ -11,6 +11,7 @@ import {
 	assert,
 	binarySearchLessOrEqual,
 	closedIntervalsOverlap,
+	isAllowSharedBufferSource,
 	isNumber,
 	isWebKit,
 	MaybePromise,
@@ -107,11 +108,7 @@ export class BufferSource extends Source {
 	 * or `ArrayBufferView`.
 	 */
 	constructor(buffer: AllowSharedBufferSource) {
-		if (
-			!(buffer instanceof ArrayBuffer)
-			&& !(typeof SharedArrayBuffer !== 'undefined' && buffer instanceof SharedArrayBuffer)
-			&& !ArrayBuffer.isView(buffer)
-		) {
+		if (!isAllowSharedBufferSource(buffer)) {
 			throw new TypeError('buffer must be an ArrayBuffer, SharedArrayBuffer, or ArrayBufferView.');
 		}
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -9,10 +9,16 @@
 import type { FileHandle } from 'node:fs/promises';
 import {
 	assert,
+	awaitPromiseLike,
 	binarySearchLessOrEqual,
 	closedIntervalsOverlap,
 	isAllowSharedBufferSource,
+	isBlob,
+	isFirefox,
 	isNumber,
+	isPromiseLike,
+	isReadableStream,
+	isUint8Array,
 	isWebKit,
 	MaybePromise,
 	mergeRequestInit,
@@ -64,7 +70,8 @@ export abstract class Source {
 			throw new InputDisposedError();
 		}
 
-		return this._sizePromise ??= Promise.resolve(this._retrieveSize());
+		const size = this._retrieveSize();
+		return this._sizePromise ??= isPromiseLike(size) ? awaitPromiseLike(size) : Promise.resolve(size);
 	}
 
 	/**
@@ -170,7 +177,7 @@ export class BlobSource extends Source {
 	 * [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
 	 */
 	constructor(blob: Blob, options: BlobSourceOptions = {}) {
-		if (!(blob instanceof Blob)) {
+		if (!isBlob(blob)) {
 			throw new TypeError('blob must be a Blob.');
 		}
 		if (!options || typeof options !== 'object') {
@@ -221,7 +228,7 @@ export class BlobSource extends Source {
 			// - ReadableStream stalls under backpressure (especially video)
 			// Affects Safari and all iOS browsers (Chrome, Firefox, etc.).
 			// Use arrayBuffer() fallback for WebKit browsers.
-			if ('stream' in this._blob && !isWebKit()) {
+			if ('stream' in this._blob && !isWebKit() && !isFirefox()) {
 				// Get a reader of the blob starting at the required offset, and then keep it around
 				const slice = this._blob.slice(worker.currentPos);
 				reader = slice.stream().getReader();
@@ -248,14 +255,17 @@ export class BlobSource extends Source {
 				this.onread?.(worker.currentPos, worker.currentPos + value.length);
 				this._orchestrator.supplyWorkerData(worker, value);
 			} else {
-				const data = await this._blob.slice(worker.currentPos, worker.targetPos).arrayBuffer();
+				const data = await awaitPromiseLike(
+					this._blob.slice(worker.currentPos, worker.targetPos).arrayBuffer(),
+				);
+				const normalizedBytes = new Uint8Array(data).slice();
 
 				if (worker.aborted) {
 					break;
 				}
 
 				this.onread?.(worker.currentPos, worker.currentPos + data.byteLength);
-				this._orchestrator.supplyWorkerData(worker, new Uint8Array(data));
+				this._orchestrator.supplyWorkerData(worker, normalizedBytes);
 			}
 		}
 
@@ -803,7 +813,7 @@ export class StreamSource extends Source {
 	_retrieveSize(): MaybePromise<number> {
 		const result = this._options.getSize();
 
-		if (result instanceof Promise) {
+		if (isPromiseLike(result)) {
 			return result.then((size) => {
 				if (!Number.isInteger(size) || size < 0) {
 					throw new TypeError('options.getSize must return or resolve to a non-negative integer.');
@@ -834,13 +844,13 @@ export class StreamSource extends Source {
 			const originalTargetPos = worker.targetPos;
 
 			let data = this._options.read(worker.currentPos, originalTargetPos);
-			if (data instanceof Promise) data = await data;
+			if (isPromiseLike(data)) data = await data;
 
 			if (worker.aborted) {
 				break;
 			}
 
-			if (data instanceof Uint8Array) {
+			if (isUint8Array(data)) {
 				data = toUint8Array(data); // Normalize things like Node.js Buffer to Uint8Array
 
 				if (data.length !== originalTargetPos - worker.currentPos) {
@@ -854,7 +864,7 @@ export class StreamSource extends Source {
 
 				this.onread?.(worker.currentPos, worker.currentPos + data.length);
 				this._orchestrator.supplyWorkerData(worker, data);
-			} else if (data instanceof ReadableStream) {
+			} else if (isReadableStream(data)) {
 				const reader = data.getReader();
 
 				while (worker.currentPos < originalTargetPos && !worker.aborted) {
@@ -873,7 +883,7 @@ export class StreamSource extends Source {
 						break;
 					}
 
-					if (!(value instanceof Uint8Array)) {
+					if (!isUint8Array(value)) {
 						throw new TypeError('ReadableStream returned by options.read must yield Uint8Array chunks.');
 					}
 
@@ -957,7 +967,7 @@ export class ReadableStreamSource extends Source {
 
 	/** Creates a new {@link ReadableStreamSource} backed by the specified `ReadableStream<Uint8Array>`. */
 	constructor(stream: ReadableStream<Uint8Array>, options: ReadableStreamSourceOptions = {}) {
-		if (!(stream instanceof ReadableStream)) {
+		if (!isReadableStream(stream)) {
 			throw new TypeError('stream must be a ReadableStream.');
 		}
 		if (!options || typeof options !== 'object') {

--- a/src/wave/wave-demuxer.ts
+++ b/src/wave/wave-demuxer.ts
@@ -12,7 +12,7 @@ import { Input } from '../input';
 import { InputAudioTrack, InputAudioTrackBacking } from '../input-track';
 import { PacketRetrievalOptions } from '../media-sink';
 import { DEFAULT_TRACK_DISPOSITION, MetadataTags } from '../metadata';
-import { assert, UNDETERMINED_LANGUAGE } from '../misc';
+import { assert, isPromiseLike, UNDETERMINED_LANGUAGE } from '../misc';
 import { EncodedPacket, PLACEHOLDER_DATA } from '../packet';
 import { readAscii, readBytes, Reader, readU16, readU32, readU64 } from '../reader';
 import { ID3_V2_HEADER_SIZE, parseId3V2Tag, readId3V2Header } from '../id3';
@@ -52,7 +52,7 @@ export class WaveDemuxer extends Demuxer {
 	async readMetadata() {
 		return this.metadataPromise ??= (async () => {
 			let slice = this.reader.requestSlice(0, 12);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			assert(slice);
 
 			const riffType = readAscii(slice, 4);
@@ -77,7 +77,7 @@ export class WaveDemuxer extends Demuxer {
 
 			while (totalFileSize === null || currentPos < totalFileSize) {
 				let slice = this.reader.requestSlice(currentPos, 8);
-				if (slice instanceof Promise) slice = await slice;
+				if (isPromiseLike(slice)) slice = await slice;
 				if (!slice) break;
 
 				const chunkId = readAscii(slice, 4);
@@ -103,7 +103,7 @@ export class WaveDemuxer extends Demuxer {
 					// File and data chunk sizes are defined in here instead
 
 					let ds64Slice = this.reader.requestSlice(startPos, chunkSize);
-					if (ds64Slice instanceof Promise) ds64Slice = await ds64Slice;
+					if (isPromiseLike(ds64Slice)) ds64Slice = await ds64Slice;
 					if (!ds64Slice) break;
 
 					const riffChunkSize = readU64(ds64Slice, littleEndian);
@@ -136,7 +136,7 @@ export class WaveDemuxer extends Demuxer {
 
 	private async parseFmtChunk(startPos: number, size: number, littleEndian: boolean) {
 		let slice = this.reader.requestSlice(startPos, size);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return; // File too short
 
 		let formatTag = readU16(slice, littleEndian);
@@ -184,7 +184,7 @@ export class WaveDemuxer extends Demuxer {
 
 	private async parseListChunk(startPos: number, size: number, littleEndian: boolean) {
 		let slice = this.reader.requestSlice(startPos, size);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return; // File too short
 
 		const infoType = readAscii(slice, 4);
@@ -281,7 +281,7 @@ export class WaveDemuxer extends Demuxer {
 	private async parseId3Chunk(startPos: number, size: number) {
 		// Parse ID3 tag embedded in WAV file (non-default, but used a lot in practice anyway)
 		let slice = this.reader.requestSlice(startPos, size);
-		if (slice instanceof Promise) slice = await slice;
+		if (isPromiseLike(slice)) slice = await slice;
 		if (!slice) return; // File too short
 
 		const id3V2Header = readId3V2Header(slice);
@@ -449,7 +449,7 @@ class WaveAudioTrackBacking implements InputAudioTrackBacking {
 			// requested slice actually exists.
 
 			let slice = this.demuxer.reader.requestSlice(this.demuxer.dataStart + startOffset, sizeInBytes);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 
 			if (!slice) {
 				return null;
@@ -461,7 +461,7 @@ class WaveAudioTrackBacking implements InputAudioTrackBacking {
 			data = PLACEHOLDER_DATA;
 		} else {
 			let slice = this.demuxer.reader.requestSlice(this.demuxer.dataStart + startOffset, sizeInBytes);
-			if (slice instanceof Promise) slice = await slice;
+			if (isPromiseLike(slice)) slice = await slice;
 			assert(slice);
 
 			data = readBytes(slice, sizeInBytes);

--- a/test/node/cross-realm-buffer-source.test.ts
+++ b/test/node/cross-realm-buffer-source.test.ts
@@ -1,14 +1,49 @@
 import vm from 'node:vm';
 import { expect, test } from 'vitest';
 import { validateAudioChunkMetadata, validateVideoChunkMetadata } from '../../src/codec.js';
-import { isArrayBuffer } from '../../src/misc.js';
+import { isArrayBuffer, isBlob, isPromiseLike, isUint8Array } from '../../src/misc.js';
+import { RichImageData } from '../../src/metadata.js';
+import { EncodedPacket } from '../../src/packet.js';
 import { AudioSample, VideoSample } from '../../src/sample.js';
-import { BufferSource } from '../../src/source.js';
+import { BlobSource, BufferSource } from '../../src/source.js';
+
+const createConstructorDenyingProxy = () => new Proxy({}, {
+	getPrototypeOf() {
+		throw new Error('Permission denied to access property "constructor"');
+	},
+});
 
 const createCrossRealmArrayBuffer = (byteLength: number) => {
 	const value: unknown = vm.runInNewContext(`new ArrayBuffer(${byteLength})`);
 	if (!isArrayBuffer(value)) {
 		throw new Error('Expected vm context to return an ArrayBuffer.');
+	}
+	return value;
+};
+
+const createCrossRealmUint8Array = (byteLength: number) => {
+	const value: unknown = vm.runInNewContext(`new Uint8Array(${byteLength})`);
+	if (!isUint8Array(value)) {
+		throw new Error('Expected vm context to return a Uint8Array.');
+	}
+	return value;
+};
+
+const createCrossRealmBlob = () => {
+	const value: unknown = vm.runInNewContext(`new Blob([new Uint8Array([1, 2, 3])])`, {
+		Blob,
+		Uint8Array,
+	});
+	if (!isBlob(value)) {
+		throw new Error('Expected vm context to return a Blob.');
+	}
+	return value;
+};
+
+const createCrossRealmPromise = () => {
+	const value: unknown = vm.runInNewContext('Promise.resolve(1)');
+	if (!isPromiseLike(value)) {
+		throw new Error('Expected vm context to return a Promise-like value.');
 	}
 	return value;
 };
@@ -60,4 +95,42 @@ test('sample constructors accept cross-realm ArrayBuffers', () => {
 		timestamp: 0,
 	});
 	audioSample.close();
+});
+
+test('BufferSource accepts a cross-realm Uint8Array', () => {
+	const bytes = createCrossRealmUint8Array(16);
+
+	expect(() => new BufferSource(bytes)).not.toThrow();
+});
+
+test('BlobSource accepts a cross-realm Blob', () => {
+	const blob = createCrossRealmBlob();
+
+	expect(() => new BlobSource(blob)).not.toThrow();
+});
+
+test('EncodedPacket accepts a cross-realm Uint8Array', () => {
+	const bytes = createCrossRealmUint8Array(16);
+
+	expect(() => new EncodedPacket(bytes, 'key', 0, 1)).not.toThrow();
+});
+
+test('RichImageData accepts a cross-realm Uint8Array', () => {
+	const bytes = createCrossRealmUint8Array(16);
+
+	expect(() => new RichImageData(bytes, 'image/png')).not.toThrow();
+});
+
+test('promise helper accepts a cross-realm Promise', () => {
+	const promise = createCrossRealmPromise();
+
+	expect(isPromiseLike(promise)).toBe(true);
+});
+
+test('buffer predicates do not throw when instanceof prototype lookup throws', () => {
+	const value = createConstructorDenyingProxy();
+
+	expect(() => isArrayBuffer(value)).not.toThrow();
+	expect(() => isUint8Array(value)).not.toThrow();
+	expect(() => isBlob(value)).not.toThrow();
 });

--- a/test/node/cross-realm-buffer-source.test.ts
+++ b/test/node/cross-realm-buffer-source.test.ts
@@ -1,0 +1,63 @@
+import vm from 'node:vm';
+import { expect, test } from 'vitest';
+import { validateAudioChunkMetadata, validateVideoChunkMetadata } from '../../src/codec.js';
+import { isArrayBuffer } from '../../src/misc.js';
+import { AudioSample, VideoSample } from '../../src/sample.js';
+import { BufferSource } from '../../src/source.js';
+
+const createCrossRealmArrayBuffer = (byteLength: number) => {
+	const value: unknown = vm.runInNewContext(`new ArrayBuffer(${byteLength})`);
+	if (!isArrayBuffer(value)) {
+		throw new Error('Expected vm context to return an ArrayBuffer.');
+	}
+	return value;
+};
+
+test('chunk metadata validation accepts cross-realm ArrayBuffers', () => {
+	const description = createCrossRealmArrayBuffer(4);
+
+	expect(() => validateVideoChunkMetadata({
+		decoderConfig: {
+			codec: 'avc1.42001f',
+			codedWidth: 2,
+			codedHeight: 2,
+			description,
+		},
+	})).not.toThrow();
+
+	expect(() => validateAudioChunkMetadata({
+		decoderConfig: {
+			codec: 'mp4a.40.2',
+			numberOfChannels: 2,
+			sampleRate: 48000,
+			description,
+		},
+	})).not.toThrow();
+});
+
+test('BufferSource accepts a cross-realm ArrayBuffer', () => {
+	const bytes = createCrossRealmArrayBuffer(16);
+
+	expect(() => new BufferSource(bytes)).not.toThrow();
+});
+
+test('sample constructors accept cross-realm ArrayBuffers', () => {
+	const videoBytes = createCrossRealmArrayBuffer(16);
+	const videoSample = new VideoSample(videoBytes, {
+		codedWidth: 2,
+		codedHeight: 2,
+		format: 'RGBA',
+		timestamp: 0,
+	});
+	videoSample.close();
+
+	const audioBytes = createCrossRealmArrayBuffer(16);
+	const audioSample = new AudioSample({
+		data: audioBytes,
+		numberOfChannels: 2,
+		format: 's16',
+		sampleRate: 48000,
+		timestamp: 0,
+	});
+	audioSample.close();
+});


### PR DESCRIPTION
TODO: Check if there are any other options to achieve this without having to change the entire project.

This PR fixes a quirk that currently fails the validations where cross-realm ArrayBuffers cause errors, but they are technically fine.

I added tests for this, but here is also a html version of it:
```
<!doctype html>
<meta charset="utf-8" />
<pre id="out"></pre>
<script type="module">
  const out = document.getElementById('out');
  const log = (value) => (out.textContent += `${value}\n`);

  const { validateVideoChunkMetadata } = await import(
    'https://unpkg.com/mediabunny@1.39.1/dist/modules/src/codec.js'
  );

  const iframe = document.createElement('iframe');
  iframe.srcdoc = '<!doctype html>';
  document.body.appendChild(iframe);
  await new Promise((resolve) => (iframe.onload = resolve));

  const crossRealmBuffer = new iframe.contentWindow.ArrayBuffer(4);

  log(`instanceof ArrayBuffer: ${crossRealmBuffer instanceof ArrayBuffer}`);
  log(`toString tag: ${Object.prototype.toString.call(crossRealmBuffer)}`);

  try {
    validateVideoChunkMetadata({
      decoderConfig: {
        codec: 'avc1.42001f',
        codedWidth: 2,
        codedHeight: 2,
        description: crossRealmBuffer,
      },
    });
    log('validation passed');
  } catch (error) {
    log(String(error));
  }

  iframe.remove();
</script>
```

Context: I work on browser extensions and I always have to "fight" with the browser sandbox when it comes to this. This issue only occurred in Firefox, Chrome and Safari pass these checks just fine. The HTML reprod fail in all browsers tho, I didn't have time to create a browser extension reprod, but I don't think it necessary.