### PR TITLE
feat: expose buffered source and track ranges

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ export {
 } from './output';
 export {
 	Source,
+	BufferedByteRange,
 	BlobSource,
 	BlobSourceOptions,
 	BufferSource,
@@ -173,6 +174,7 @@ export {
 	InputTrack,
 	InputVideoTrack,
 	InputAudioTrack,
+	BufferedTimeRange,
 	PacketStats,
 } from './input-track';
 export {

--- a/src/input-track.ts
+++ b/src/input-track.ts
@@ -30,6 +30,16 @@ export type PacketStats = {
 	averageBitrate: number;
 };
 
+/**
+ * A buffered media time range in seconds. The end timestamp is exclusive.
+ * @group Input files & tracks
+ * @public
+ */
+export type BufferedTimeRange = {
+	start: number;
+	end: number;
+};
+
 export interface InputTrackBacking {
 	getId(): number;
 	getNumber(): number;
@@ -41,6 +51,7 @@ export interface InputTrackBacking {
 	getDisposition(): TrackDisposition;
 	getFirstTimestamp(): Promise<number>;
 	computeDuration(): Promise<number>;
+	getBufferedTimeRanges?(): Promise<BufferedTimeRange[]>;
 
 	getFirstPacket(options: PacketRetrievalOptions): Promise<EncodedPacket | null>;
 	getPacket(timestamp: number, options: PacketRetrievalOptions): Promise<EncodedPacket | null>;
@@ -158,6 +169,10 @@ export abstract class InputTrack {
 	/** Returns the end timestamp of the last packet of this track, in seconds. */
 	computeDuration() {
 		return this._backing.computeDuration();
+	}
+
+	async getBufferedTimeRanges() {
+		return this._backing.getBufferedTimeRanges?.() ?? [];
 	}
 
 	/**

--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -35,6 +35,7 @@ import {
 import { Demuxer } from '../demuxer';
 import { Input } from '../input';
 import {
+	BufferedTimeRange,
 	InputAudioTrack,
 	InputAudioTrackBacking,
 	InputTrack,
@@ -2465,6 +2466,29 @@ abstract class IsobmffTrackBacking implements InputTrackBacking {
 		return firstPacket?.timestamp ?? 0;
 	}
 
+	async getBufferedTimeRanges(): Promise<BufferedTimeRange[]> {
+		const bufferedByteRanges = this.internalTrack.demuxer.reader.source.getBufferedByteRanges();
+		if (bufferedByteRanges.length === 0) {
+			return [];
+		}
+
+		const sampleTable = this.internalTrack.demuxer.getSampleTableForTrack(this.internalTrack);
+		if (sampleTableIsEmpty(sampleTable)) {
+			return [];
+		}
+
+		const ranges: BufferedTimeRange[] = [];
+		appendSampleTableBufferedTimeRanges(
+			ranges,
+			sampleTable,
+			bufferedByteRanges,
+			this.internalTrack.timescale,
+			this.internalTrack.editListOffset,
+		);
+
+		return mergeBufferedTimeRanges(ranges, 1 / this.internalTrack.timescale);
+	}
+
 	async getFirstPacket(options: PacketRetrievalOptions) {
 		const regularPacket = await this.fetchPacketForSampleIndex(0, options);
 		if (regularPacket || !this.internalTrack.demuxer.isFragmented) {
@@ -3152,6 +3176,61 @@ const getSampleInfo = (sampleTable: SampleTable, sampleIndex: number): SampleInf
 			? binarySearchExact(sampleTable.keySampleIndices, sampleIndex, x => x) !== -1
 			: true,
 	};
+};
+
+const appendSampleTableBufferedTimeRanges = (
+	ranges: BufferedTimeRange[],
+	sampleTable: SampleTable,
+	bufferedByteRanges: { start: number; end: number }[],
+	timescale: number,
+	editListOffset: number,
+) => {
+	for (let sampleIndex = 0; sampleIndex < sampleTable.sampleSizes.length; sampleIndex++) {
+		const sampleInfo = getSampleInfo(sampleTable, sampleIndex);
+		if (!sampleInfo) {
+			continue;
+		}
+
+		const sampleStart = sampleInfo.sampleOffset;
+		const sampleEnd = sampleInfo.sampleOffset + sampleInfo.sampleSize;
+		const isBuffered = bufferedByteRanges.some(
+			range => range.start <= sampleStart && sampleEnd <= range.end,
+		);
+		if (!isBuffered) {
+			continue;
+		}
+
+		ranges.push({
+			start: (sampleInfo.presentationTimestamp - editListOffset) / timescale,
+			end: (sampleInfo.presentationTimestamp - editListOffset + sampleInfo.duration) / timescale,
+		});
+	}
+};
+
+const mergeBufferedTimeRanges = (
+	ranges: BufferedTimeRange[],
+	epsilon: number,
+) => {
+	if (ranges.length <= 1) {
+		return ranges;
+	}
+
+	ranges.sort((a, b) => a.start - b.start);
+	const merged: BufferedTimeRange[] = [ranges[0]!];
+
+	for (let i = 1; i < ranges.length; i++) {
+		const current = ranges[i]!;
+		const previous = merged[merged.length - 1]!;
+
+		if (current.start <= previous.end + epsilon) {
+			previous.end = Math.max(previous.end, current.end);
+			continue;
+		}
+
+		merged.push({ ...current });
+	}
+
+	return merged;
 };
 
 const getNextKeyframeIndexForSample = (sampleTable: SampleTable, sampleIndex: number) => {

--- a/src/source.ts
+++ b/src/source.ts
@@ -35,6 +35,16 @@ export type ReadResult = {
 };
 
 /**
+ * A cached byte range in a source. The end offset is exclusive.
+ * @group Input sources
+ * @public
+ */
+export type BufferedByteRange = {
+	start: number;
+	end: number;
+};
+
+/**
  * The source base class, representing a resource from which bytes can be read.
  * @group Input sources
  * @public
@@ -87,6 +97,17 @@ export abstract class Source {
 
 	/** Called each time data is retrieved from the source. Will be called with the retrieved range (end exclusive). */
 	onread: ((start: number, end: number) => unknown) | null = null;
+
+	/**
+	 * Returns the byte ranges that are currently retained by this source's internal cache.
+	 * The returned ranges are end-exclusive and sorted by `start`.
+	 *
+	 * Sources that keep the entire resource in memory return the full range. Sources without
+	 * an inspectable cache return an empty array.
+	 */
+	getBufferedByteRanges(): BufferedByteRange[] {
+		return [];
+	}
 }
 
 /**
@@ -143,6 +164,10 @@ export class BufferSource extends Source {
 
 	/** @internal */
 	_dispose() {}
+
+	override getBufferedByteRanges(): BufferedByteRange[] {
+		return [{ start: 0, end: this._bytes.byteLength }];
+	}
 }
 
 /**
@@ -273,6 +298,10 @@ export class BlobSource extends Source {
 	/** @internal */
 	_dispose() {
 		this._orchestrator.dispose();
+	}
+
+	override getBufferedByteRanges(): BufferedByteRange[] {
+		return this._orchestrator.getBufferedByteRanges();
 	}
 }
 
@@ -631,6 +660,10 @@ export class UrlSource extends Source {
 	_dispose() {
 		this._orchestrator.dispose();
 	}
+
+	override getBufferedByteRanges(): BufferedByteRange[] {
+		return this._orchestrator.getBufferedByteRanges();
+	}
 }
 
 /**
@@ -710,6 +743,10 @@ export class FilePathSource extends Source {
 		this._streamSource._dispose();
 		void this._fileHandle?.close();
 		this._fileHandle = null;
+	}
+
+	override getBufferedByteRanges(): BufferedByteRange[] {
+		return this._streamSource.getBufferedByteRanges();
 	}
 }
 
@@ -901,6 +938,10 @@ export class StreamSource extends Source {
 	_dispose() {
 		this._orchestrator.dispose();
 		this._options.dispose?.();
+	}
+
+	override getBufferedByteRanges(): BufferedByteRange[] {
+		return this._orchestrator.getBufferedByteRanges();
 	}
 }
 
@@ -1166,6 +1207,10 @@ export class ReadableStreamSource extends Source {
 	_dispose() {
 		this._pendingSlices.length = 0;
 		this._cache.length = 0;
+	}
+
+	override getBufferedByteRanges(): BufferedByteRange[] {
+		return this._cache.map(entry => ({ start: entry.start, end: entry.end }));
 	}
 }
 
@@ -1703,5 +1748,9 @@ class ReadOrchestrator {
 		this.workers.length = 0;
 		this.cache.length = 0;
 		this.disposed = true;
+	}
+
+	getBufferedByteRanges(): BufferedByteRange[] {
+		return this.cache.map(entry => ({ start: entry.start, end: entry.end }));
 	}
 }

--- a/test/node/buffered-time-ranges.test.ts
+++ b/test/node/buffered-time-ranges.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'vitest';
+import path from 'node:path';
+import nodeFs from 'node:fs/promises';
+import { BufferSource, EncodedPacketSink, Input, MP4, StreamSource } from '../../src/index.js';
+
+const __dirname = new URL('.', import.meta.url).pathname;
+
+test('InputTrack.getBufferedTimeRanges returns one full end-exclusive media range when the entire MP4 source is buffered', async () => {
+	const filePath = path.join(__dirname, '..', 'public/video.mp4');
+	const bytes = await nodeFs.readFile(filePath);
+
+	using input = new Input({
+		source: new BufferSource(bytes),
+		formats: [MP4],
+	});
+
+	const track = await input.getPrimaryVideoTrack();
+	expect(track).toBeTruthy();
+	if (!track) {
+		return;
+	}
+
+	const bufferedRanges = await track.getBufferedTimeRanges();
+	const firstTimestamp = await track.getFirstTimestamp();
+	const duration = await track.computeDuration();
+
+	expect(bufferedRanges).toHaveLength(1);
+	expect(bufferedRanges[0]!.start).toBeCloseTo(firstTimestamp, 3);
+	expect(bufferedRanges[0]!.end).toBeCloseTo(duration, 3);
+	expect(bufferedRanges[0]!.start).toBeLessThan(bufferedRanges[0]!.end);
+});
+
+test('InputTrack.getBufferedTimeRanges exposes only the fetched media region after a random-access read', async () => {
+	const filePath = path.join(__dirname, '..', 'public/video.mp4');
+	const bytes = await nodeFs.readFile(filePath);
+	const requestedTimestamp = 1.0;
+	const distantUnfetchedTimestamp = 4.5; // Near the end of public/video.mp4, outside the first fetched region.
+
+	using input = new Input({
+		source: new StreamSource({
+			getSize: () => bytes.length,
+			read: (start, end) => bytes.subarray(start, end),
+			prefetchProfile: 'none',
+			maxCacheSize: 1024 * 1024,
+		}),
+		formats: [MP4],
+	});
+
+	const track = await input.getPrimaryVideoTrack();
+	expect(track).toBeTruthy();
+	if (!track) {
+		return;
+	}
+
+	expect(await track.getBufferedTimeRanges()).toEqual([]);
+
+	const sink = new EncodedPacketSink(track);
+	await sink.getPacket(requestedTimestamp);
+
+	const bufferedRanges = await track.getBufferedTimeRanges();
+
+	expect(bufferedRanges.length).toBeGreaterThan(0);
+	expect(
+		bufferedRanges.some(range => range.start <= requestedTimestamp && requestedTimestamp < range.end),
+	).toBe(true);
+	expect(
+		bufferedRanges.some(
+			range => range.start <= distantUnfetchedTimestamp && distantUnfetchedTimestamp < range.end,
+		),
+	).toBe(false);
+});

--- a/test/node/source-buffered-ranges.test.ts
+++ b/test/node/source-buffered-ranges.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest';
+import { BufferSource, ReadableStreamSource, StreamSource } from '../../src/source.js';
+
+test('BufferSource exposes the entire backing buffer as one end-exclusive buffered byte range', () => {
+	const source = new BufferSource(new Uint8Array(16));
+
+	expect(source.getBufferedByteRanges()).toEqual([{ start: 0, end: 16 }]);
+});
+
+test('StreamSource exposes only the currently retained cached byte range, not unread regions', async () => {
+	const bytes = new Uint8Array(16).map((_, index) => index);
+	const source = new StreamSource({
+		getSize: () => bytes.length,
+		read: (start, end) => bytes.slice(start, end),
+		prefetchProfile: 'none',
+	});
+
+	await source.getSize();
+	expect(source.getBufferedByteRanges()).toEqual([]);
+
+	await source._read(4, 8);
+
+	expect(source.getBufferedByteRanges()).toEqual([{ start: 4, end: 8 }]);
+	expect(source.getBufferedByteRanges()).not.toContainEqual({ start: 8, end: 16 });
+});
+
+test('ReadableStreamSource reports retained cached chunks as end-exclusive byte ranges in stream order', async () => {
+	const source = new ReadableStreamSource(new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new Uint8Array([0, 1, 2, 3]));
+			controller.enqueue(new Uint8Array([4, 5, 6, 7]));
+			controller.close();
+		},
+	}));
+
+	expect(source.getBufferedByteRanges()).toEqual([]);
+
+	await source._read(0, 6);
+
+	expect(source.getBufferedByteRanges()).toEqual([
+		{ start: 0, end: 4 },
+		{ start: 4, end: 8 },
+	]);
+	expect(source.getBufferedByteRanges()).not.toContainEqual({ start: 0, end: 6 });
+});


### PR DESCRIPTION
Closes #346.

## Changes

- add `Source.getBufferedByteRanges()`
- add `InputTrack.getBufferedTimeRanges()`
- implement `InputTrack.getBufferedTimeRanges()` for on-demand ISOBMFF/MP4

## Tests

- `test/node/source-buffered-ranges.test.ts`
- `test/node/buffered-time-ranges.test.ts`