### PR TITLE
Include actual HTTP status code when unexpectedly did not get 206

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -533,8 +533,9 @@ export class UrlSource extends Source {
 
 			if (worker.currentPos > 0 && response.status !== 206) {
 				throw new Error(
-					'HTTP server did not respond with 206 Partial Content to a range request. To enable efficient media'
-					+ ' file streaming across a network, please make sure your server supports range requests.',
+					'HTTP server did not respond with 206 Partial Content to a range request (received '
+					+ `${response.status} ${response.statusText}). To enable efficient media file streaming`
+					+ ' across a network, please make sure your server supports range requests.',
 				);
 			}
 


### PR DESCRIPTION
Bug https://discord.com/channels/809501355504959528/1445495265028079718/1445556450234466345 seems to affect a couple of people.

For now I just would like to surface a bit more information to learn more about the problem if it happens again in the future.