### PR TITLE
Add sidx box parsing and expose via Input.getSegmentIndex

### DIFF
--- a/src/demuxer.ts
+++ b/src/demuxer.ts
@@ -8,6 +8,7 @@
 
 import { Input } from './input';
 import { InputTrackBacking } from './input-track';
+import { SidxBox } from './isobmff/isobmff-misc';
 import { MetadataTags } from './metadata';
 
 /**
@@ -36,6 +37,10 @@ export abstract class Demuxer {
 	abstract getTrackBackings(): Promise<InputTrackBacking[]>;
 	abstract getMimeType(): Promise<string>;
 	abstract getMetadataTags(): Promise<MetadataTags>;
+
+	async getSegmentIndex(): Promise<SidxBox[]> {
+		return [];
+	}
 
 	dispose() {
 		// Can be overridden

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,8 @@ export {
 } from './misc';
 export {
 	PsshBox,
+	SidxBox,
+	SidxReference,
 } from './isobmff/isobmff-misc';
 export {
 	Rational,

--- a/src/input.ts
+++ b/src/input.ts
@@ -520,6 +520,16 @@ export class Input<S extends Source = Source> extends EventEmitter<InputEvents> 
 	}
 
 	/**
+	 * Returns parsed `sidx` (Segment Index) boxes from the file, if any. Multiple boxes are valid (typically
+	 * one per track, distinguished by their `referenceID`). Returns an empty array for formats without a
+	 * `sidx` equivalent.
+	 */
+	async getSegmentIndex() {
+		const demuxer = await this._getDemuxer();
+		return demuxer.getSegmentIndex();
+	}
+
+	/**
 	 * Disposes this input and frees connected resources. When an input is disposed, ongoing read operations will be
 	 * canceled, all future read operations will fail, any open decoders will be closed, and all ongoing media sink
 	 * operations will be canceled. Disallowed and canceled operations will throw an {@link InputDisposedError}.

--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -64,7 +64,14 @@ import {
 	HEX_STRING_REGEX,
 } from '../misc';
 import { EncodedPacket, PLACEHOLDER_DATA } from '../packet';
-import { buildIsobmffMimeType, parsePsshBoxContents, psshBoxesAreEqual, PsshBox } from './isobmff-misc';
+import {
+	buildIsobmffMimeType,
+	parsePsshBoxContents,
+	parseSidxBoxContents,
+	psshBoxesAreEqual,
+	PsshBox,
+	SidxBox,
+} from './isobmff-misc';
 import {
 	MAX_BOX_HEADER_SIZE,
 	MIN_BOX_HEADER_SIZE,
@@ -303,6 +310,7 @@ export class IsobmffDemuxer extends Demuxer {
 	isFragmented = false;
 	fragmentTrackDefaults: FragmentTrackDefaults[] = [];
 	psshBoxes: PsshBox[] = [];
+	sidxBoxes: SidxBox[] = [];
 	currentFragment: Fragment | null = null;
 	/**
 	 * Caches the last fragment that was read. Based on the assumption that there will be multiple reads to the
@@ -344,6 +352,11 @@ export class IsobmffDemuxer extends Demuxer {
 		return this.metadataTags;
 	}
 
+	override async getSegmentIndex() {
+		await this.readMetadata();
+		return this.sidxBoxes;
+	}
+
 	readMetadata() {
 		return this.metadataPromise ??= (async () => {
 			let currentPos = 0;
@@ -363,6 +376,16 @@ export class IsobmffDemuxer extends Demuxer {
 				if (boxInfo.name === 'ftyp' || boxInfo.name === 'styp') {
 					const majorBrand = readAscii(slice, 4);
 					this.isQuickTime = majorBrand === 'qt  ';
+				} else if (boxInfo.name === 'sidx') {
+					let sidxSlice = this.reader.requestSlice(slice.filePos, boxInfo.contentSize);
+					if (sidxSlice instanceof Promise) sidxSlice = await sidxSlice;
+					if (!sidxSlice) break;
+
+					this.sidxBoxes.push(parseSidxBoxContents(
+						readBytes(sidxSlice, boxInfo.contentSize),
+						startPos,
+						boxInfo.totalSize,
+					));
 				} else if (boxInfo.name === 'moov') {
 					// Found moov, load it
 
@@ -385,8 +408,16 @@ export class IsobmffDemuxer extends Demuxer {
 						&& this.reader.fileSize !== null
 						&& this.reader.fileSize > startPos + boxInfo.totalSize; // There's more after the moov box
 
-					break;
+					// Don't break here — keep iterating so a `sidx` that follows `moov`
+					// (DASH on-demand profile layout) is also captured. Iteration stops
+					// when we hit `moof`/`mdat` or EOF.
 				} else if (boxInfo.name === 'moof') {
+					if (this.movieTimescale !== -1) {
+						// `moov` was already parsed earlier in the same file; the rest is
+						// fragments which are read lazily.
+						break;
+					}
+
 					if (!this.input._initInput) {
 						throw new Error(
 							'"moof" box encountered with no "moov" box present; this file is likely a Segment as'

--- a/src/isobmff/isobmff-misc.ts
+++ b/src/isobmff/isobmff-misc.ts
@@ -173,6 +173,14 @@ export const parseSidxBoxContents = (
 	const referenceCount = view.getUint16(pos);
 	pos += 2;
 
+	const requiredBytes = referenceCount * 12;
+	if (pos + requiredBytes > view.byteLength) {
+		throw new Error(
+			`Incomplete sidx reference table; ${referenceCount} references need ${requiredBytes} bytes,`
+			+ ` only ${view.byteLength - pos} available.`,
+		);
+	}
+
 	const references: SidxReference[] = [];
 	for (let i = 0; i < referenceCount; i++) {
 		const sizeWord = view.getUint32(pos);

--- a/src/isobmff/isobmff-misc.ts
+++ b/src/isobmff/isobmff-misc.ts
@@ -88,3 +88,117 @@ export const psshBoxesAreEqual = (a: PsshBox, b: PsshBox) => (
 	a.systemId === b.systemId
 	&& uint8ArraysAreEqual(a.data, b.data)
 );
+
+/**
+ * One subsegment reference within a {@link SidxBox}.
+ *
+ * @group Miscellaneous
+ * @public
+ */
+export type SidxReference = {
+	/** `0` for a media subsegment, `1` for a nested `sidx`. */
+	referenceType: 0 | 1;
+	/** Size of the referenced subsegment in bytes. */
+	referencedSize: number;
+	/** Duration of the referenced subsegment, in the parent sidx's timescale. */
+	subsegmentDuration: number;
+	/** `1` if the subsegment starts with a Stream Access Point. */
+	startsWithSAP: 0 | 1;
+	/** SAP type (0-7) when `startsWithSAP` is `1`. */
+	sapType: number;
+	/** Offset from the subsegment start to the SAP, in the parent sidx's timescale. */
+	sapDeltaTime: number;
+};
+
+/**
+ * Represents a Segment Index box (`sidx`) in a fragmented MP4. Provides per-subsegment byte
+ * offsets, durations and SAP markers — the data needed to address subsegments by byte range.
+ *
+ * @group Miscellaneous
+ * @public
+ */
+export type SidxBox = {
+	/** The track ID this index applies to. */
+	referenceID: number;
+	/** Timescale of durations and timestamps in this index. */
+	timescale: number;
+	/** Earliest presentation time of the first subsegment, in this index's timescale. */
+	earliestPresentationTime: number;
+	/** Byte offset from after this `sidx` box to the first referenced subsegment. Usually `0`. */
+	firstOffset: number;
+	/** One entry per referenced subsegment, in order. */
+	references: SidxReference[];
+	/** Absolute byte offset of this `sidx` box in the file. */
+	boxStart: number;
+	/** Total size of this `sidx` box in bytes. */
+	boxSize: number;
+};
+
+export const parseSidxBoxContents = (
+	contents: Uint8Array,
+	boxStart: number,
+	boxSize: number,
+): SidxBox => {
+	const view = toDataView(contents);
+	let pos = 0;
+
+	const version = view.getUint8(pos);
+	pos += 1;
+	pos += 3; // Flags
+
+	const referenceID = view.getUint32(pos);
+	pos += 4;
+	const timescale = view.getUint32(pos);
+	pos += 4;
+
+	let earliestPresentationTime: number;
+	let firstOffset: number;
+	if (version === 0) {
+		earliestPresentationTime = view.getUint32(pos);
+		pos += 4;
+		firstOffset = view.getUint32(pos);
+		pos += 4;
+	} else {
+		const eptHi = view.getUint32(pos);
+		const eptLo = view.getUint32(pos + 4);
+		earliestPresentationTime = eptHi * 2 ** 32 + eptLo;
+		pos += 8;
+		const foHi = view.getUint32(pos);
+		const foLo = view.getUint32(pos + 4);
+		firstOffset = foHi * 2 ** 32 + foLo;
+		pos += 8;
+	}
+
+	pos += 2; // Reserved
+	const referenceCount = view.getUint16(pos);
+	pos += 2;
+
+	const references: SidxReference[] = [];
+	for (let i = 0; i < referenceCount; i++) {
+		const sizeWord = view.getUint32(pos);
+		pos += 4;
+		const subsegmentDuration = view.getUint32(pos);
+		pos += 4;
+		const sapWord = view.getUint32(pos);
+		pos += 4;
+
+		references.push({
+			referenceType: ((sizeWord >>> 31) & 0x1) as 0 | 1,
+			referencedSize: sizeWord & 0x7fffffff,
+			subsegmentDuration,
+			startsWithSAP: ((sapWord >>> 31) & 0x1) as 0 | 1,
+			sapType: (sapWord >>> 28) & 0x7,
+			sapDeltaTime: sapWord & 0x0fffffff,
+		});
+	}
+
+	return {
+		referenceID,
+		timescale,
+		earliestPresentationTime,
+		firstOffset,
+		references,
+		boxStart,
+		boxSize,
+	};
+};

--- a/test/browser/cmaf.test.ts
+++ b/test/browser/cmaf.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { Output } from '../../src/output.js';
-import { CmafOutputFormat } from '../../src/output-format.js';
+import { CmafOutputFormat, Mp4OutputFormat } from '../../src/output-format.js';
 import { BufferTarget } from '../../src/target.js';
 import { CanvasSource } from '../../src/media-source.js';
 import { QUALITY_HIGH } from '../../src/encode.js';
@@ -83,6 +83,97 @@ test('CMAF with video track', async () => {
 	const tracks = await segmentInputWithInit.getTracks();
 	expect(tracks).toHaveLength(1);
 	expect(tracks[0]!.isVideoTrack()).toBe(true);
+});
+
+test('Input.getSegmentIndex parses sidx from a CMAF segment file', async () => {
+	const initTarget = new BufferTarget();
+
+	const output = new Output({
+		format: new CmafOutputFormat(),
+		target: new BufferTarget(),
+		initTarget: () => initTarget,
+	});
+
+	const canvas = new OffscreenCanvas(640, 480);
+	const ctx = canvas.getContext('2d')!;
+	const videoSource = new CanvasSource(canvas, {
+		codec: 'avc',
+		bitrate: QUALITY_HIGH,
+	});
+	output.addVideoTrack(videoSource);
+
+	await output.start();
+
+	const fps = 30;
+	const frameDuration = 1 / fps;
+	for (let i = 0; i < fps * 2; i++) {
+		ctx.fillStyle = i % 2 === 0 ? '#ff0000' : '#00ff00';
+		ctx.fillRect(0, 0, canvas.width, canvas.height);
+		await videoSource.add(i * frameDuration, frameDuration);
+	}
+
+	await output.finalize();
+
+	using initInput = new Input({
+		source: new BufferSource(initTarget.buffer!),
+		formats: ALL_FORMATS,
+	});
+	using segmentInput = new Input({
+		source: new BufferSource(output.target.buffer!),
+		formats: ALL_FORMATS,
+		initInput,
+	});
+
+	const sidxBoxes = await segmentInput.getSegmentIndex();
+	expect(sidxBoxes.length).toBeGreaterThan(0);
+
+	for (const sidx of sidxBoxes) {
+		expect(sidx.timescale).toBeGreaterThan(0);
+		expect(sidx.references.length).toBeGreaterThan(0);
+		expect(sidx.boxStart).toBeGreaterThanOrEqual(0);
+		expect(sidx.boxSize).toBeGreaterThan(0);
+
+		for (const ref of sidx.references) {
+			expect(ref.referencedSize).toBeGreaterThan(0);
+			expect(ref.subsegmentDuration).toBeGreaterThan(0);
+			expect(ref.referenceType === 0 || ref.referenceType === 1).toBe(true);
+			expect(ref.startsWithSAP === 0 || ref.startsWithSAP === 1).toBe(true);
+		}
+	}
+});
+
+test('Input.getSegmentIndex returns empty array for non-fragmented MP4', async () => {
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+
+	const canvas = new OffscreenCanvas(640, 480);
+	const ctx = canvas.getContext('2d')!;
+	ctx.fillStyle = '#ff0000';
+	ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+	const videoSource = new CanvasSource(canvas, {
+		codec: 'avc',
+		bitrate: QUALITY_HIGH,
+	});
+	output.addVideoTrack(videoSource);
+
+	await output.start();
+	const fps = 30;
+	const frameDuration = 1 / fps;
+	for (let i = 0; i < fps; i++) {
+		await videoSource.add(i * frameDuration, frameDuration);
+	}
+	await output.finalize();
+
+	using input = new Input({
+		source: new BufferSource(output.target.buffer!),
+		formats: ALL_FORMATS,
+	});
+
+	const sidxBoxes = await input.getSegmentIndex();
+	expect(sidxBoxes).toEqual([]);
 });
 
 test('CMAF with empty video track', async () => {

--- a/test/browser/cmaf.test.ts
+++ b/test/browser/cmaf.test.ts
@@ -85,9 +85,8 @@ test('CMAF with video track', async () => {
 	expect(tracks[0]!.isVideoTrack()).toBe(true);
 });
 
-test('Input.getSegmentIndex parses sidx from a CMAF segment file', async () => {
+async function buildCmafFile(numFrames = 60) {
 	const initTarget = new BufferTarget();
-
 	const output = new Output({
 		format: new CmafOutputFormat(),
 		target: new BufferTarget(),
@@ -103,35 +102,50 @@ test('Input.getSegmentIndex parses sidx from a CMAF segment file', async () => {
 	output.addVideoTrack(videoSource);
 
 	await output.start();
-
 	const fps = 30;
 	const frameDuration = 1 / fps;
-	for (let i = 0; i < fps * 2; i++) {
+	for (let i = 0; i < numFrames; i++) {
 		ctx.fillStyle = i % 2 === 0 ? '#ff0000' : '#00ff00';
 		ctx.fillRect(0, 0, canvas.width, canvas.height);
 		await videoSource.add(i * frameDuration, frameDuration);
 	}
-
 	await output.finalize();
 
+	return {
+		initBytes: new Uint8Array(initTarget.buffer!),
+		segmentBytes: new Uint8Array(output.target.buffer!),
+	};
+}
+
+test('Input.getSegmentIndex parses sidx from a CMAF segment file', async () => {
+	const numFrames = 60;
+	const fps = 30;
+	const expectedDuration = numFrames / fps;
+	const { initBytes, segmentBytes } = await buildCmafFile(numFrames);
+
 	using initInput = new Input({
-		source: new BufferSource(initTarget.buffer!),
+		source: new BufferSource(initBytes.buffer),
 		formats: ALL_FORMATS,
 	});
 	using segmentInput = new Input({
-		source: new BufferSource(output.target.buffer!),
+		source: new BufferSource(segmentBytes.buffer),
 		formats: ALL_FORMATS,
 		initInput,
 	});
+
+	const tracks = await segmentInput.getVideoTracks();
+	const videoTrack = tracks[0]!;
+	const trackId = videoTrack.id;
 
 	const sidxBoxes = await segmentInput.getSegmentIndex();
 	expect(sidxBoxes.length).toBeGreaterThan(0);
 
 	for (const sidx of sidxBoxes) {
-		expect(sidx.timescale).toBeGreaterThan(0);
 		expect(sidx.references.length).toBeGreaterThan(0);
 		expect(sidx.boxStart).toBeGreaterThanOrEqual(0);
 		expect(sidx.boxSize).toBeGreaterThan(0);
+		expect(sidx.referenceID).toBe(trackId);
+		expect(sidx.earliestPresentationTime).toBe(0);
 
 		for (const ref of sidx.references) {
 			expect(ref.referencedSize).toBeGreaterThan(0);
@@ -139,6 +153,53 @@ test('Input.getSegmentIndex parses sidx from a CMAF segment file', async () => {
 			expect(ref.referenceType === 0 || ref.referenceType === 1).toBe(true);
 			expect(ref.startsWithSAP === 0 || ref.startsWithSAP === 1).toBe(true);
 		}
+
+		const totalReferencedBytes = sidx.references.reduce((sum, r) => sum + r.referencedSize, 0);
+		const dataAfterIndex = segmentBytes.byteLength - sidx.boxStart - sidx.boxSize - sidx.firstOffset;
+		expect(totalReferencedBytes).toBe(dataAfterIndex);
+
+		const totalDurationSec = sidx.references.reduce((s, r) => s + r.subsegmentDuration, 0)
+			/ sidx.timescale;
+		expect(totalDurationSec).toBeCloseTo(expectedDuration, 1);
+	}
+});
+
+test('Input.getSegmentIndex parses sidx from a self-contained fragmented MP4', async () => {
+	const numFrames = 60;
+	const fps = 30;
+	const expectedDuration = numFrames / fps;
+	const { initBytes, segmentBytes } = await buildCmafFile(numFrames);
+	const combined = new Uint8Array(initBytes.byteLength + segmentBytes.byteLength);
+	combined.set(initBytes, 0);
+	combined.set(segmentBytes, initBytes.byteLength);
+
+	using input = new Input({
+		source: new BufferSource(combined.buffer),
+		formats: ALL_FORMATS,
+	});
+
+	const tracks = await input.getVideoTracks();
+	expect(tracks).toHaveLength(1);
+	const videoTrack = tracks[0]!;
+	const trackId = videoTrack.id;
+
+	const sidxBoxes = await input.getSegmentIndex();
+	expect(sidxBoxes.length).toBeGreaterThan(0);
+
+	for (const sidx of sidxBoxes) {
+		expect(sidx.references.length).toBeGreaterThan(0);
+		expect(sidx.referenceID).toBe(trackId);
+		expect(sidx.earliestPresentationTime).toBe(0);
+		expect(sidx.boxStart).toBeGreaterThan(initBytes.byteLength);
+		expect(sidx.boxStart + sidx.boxSize).toBeLessThanOrEqual(combined.byteLength);
+
+		const totalReferencedBytes = sidx.references.reduce((sum, r) => sum + r.referencedSize, 0);
+		const dataAfterIndex = combined.byteLength - sidx.boxStart - sidx.boxSize - sidx.firstOffset;
+		expect(totalReferencedBytes).toBe(dataAfterIndex);
+
+		const totalDurationSec = sidx.references.reduce((s, r) => s + r.subsegmentDuration, 0)
+			/ sidx.timescale;
+		expect(totalDurationSec).toBeCloseTo(expectedDuration, 1);
 	}
 });
 


### PR DESCRIPTION
Closes #358.

Mirrors the existing `pssh` flow:

- `SidxBox` + `SidxReference` types and `parseSidxBoxContents` in `isobmff-misc.ts`.
- Inline branch in `IsobmffDemuxer.readMetadata` parses any `sidx` encountered during the file-root walk; stores onto a new `sidxBoxes` field. The walk now continues past `moov` so a `sidx` placed after it (DASH on-demand profile layout) is captured too. The `moof` branch breaks early when `movieTimescale !== -1` so a self-contained fragmented file doesn't trip the "no init file" error after parsing its own moov.
- `Demuxer.getSegmentIndex()` defaults to `[]`; ISOBMFF overrides. Other demuxers inherit the default.
- `Input.getSegmentIndex()` delegates to the demuxer.
- Roundtrip + non-fragmented tests in `test/browser/cmaf.test.ts`.

No behaviour changes for existing callers — `sidx` was previously silently skipped, now stored.

I made a little visualizer, so it can show how this box helps
<img width="745" height="724" alt="image" src="https://github.com/user-attachments/assets/7f40528a-f0b4-4ffa-8288-ed21080b305a" />


Branched off `hls` since the demuxer is being heavily modified there. Happy to rebase onto `main` if you'd prefer.