### PR TITLE
fix(input-format): recognise CMAF segments that start with sidx

### DIFF
--- a/src/input-format.ts
+++ b/src/input-format.ts
@@ -120,7 +120,8 @@ export class Mp4InputFormat extends IsobmffInputFormat {
 		if (slice instanceof Promise) slice = await slice;
 		if (!slice) return false;
 
-		return readAscii(slice, 4) === 'moof'; // Seen in HLS for example
+		const fourCc = readAscii(slice, 4);
+		return fourCc === 'moof' || fourCc === 'sidx'; // Seen in HLS for example
 	}
 
 	get name() {

--- a/test/node/hls-input.test.ts
+++ b/test/node/hls-input.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @stylistic/max-len */
 import { ALL_FORMATS, BufferSource, EncodedPacketSink, Input, InputAudioTrack, InputVideoTrack, UrlSource } from 'mediabunny';
 import { expect, test, vi } from 'vitest';
-import { HLS, HLS_FORMATS, HlsInputFormat } from '../../src/input-format.js';
+import { HLS, HLS_FORMATS, HlsInputFormat, MP4 } from '../../src/input-format.js';
 import { assert, hexStringToBytes, rejectAfter } from '../../src/misc.js';
 import { CustomPathedSource } from '../../src/source.js';
 
@@ -786,6 +786,27 @@ test.concurrent('Live HLS', { timeout: 30_000 }, async () => {
 
 	// The server doesn't answer with range requests but since it's HLS we suppress that warning
 	expect(consoleSpy).not.toHaveBeenCalled();
+});
+
+test.concurrent('Mp4InputFormat recognises a CMAF segment that starts with sidx', async () => {
+	// Sibling of the moof case fixed in #308: CMAF segments using the DASH
+	// on-demand profile (and HLS playlists derived from it) place a sidx
+	// before the moof. Without ftyp/styp at the file start the existing
+	// format probe used to bail out, producing UnsupportedInputFormatError.
+	//
+	// Repro shape (real Vimeo segment): 32 60 73 69 64 78 ...
+	// (size 0x32 60-byte sidx box header, four-cc 'sidx').
+	const bytes = new Uint8Array(12);
+	new DataView(bytes.buffer).setUint32(0, 60); // box size
+	bytes.set([0x73, 0x69, 0x64, 0x78], 4); // 'sidx'
+
+	using input = new Input({
+		source: new BufferSource(bytes),
+		formats: ALL_FORMATS,
+	});
+
+	expect(await input.canRead()).toBe(true);
+	expect(await input.getFormat()).toBe(MP4);
 });
 
 test.concurrent('#EXT-X-I-FRAME-STREAM-INF tags are parsed properly', async () => {


### PR DESCRIPTION
## Summary

Sibling case to #308. `Mp4InputFormat._canReadInput` rejects fragmented MP4 segments whose first box is `sidx`, even though the rest of the file is valid ISOBMFF and the EXT-X-MAP init segment was already fetched. The fix added in #308 covers `moof` as a permitted start box; `sidx + moof` (DASH on-demand profile / HLS playlists derived from it) was missed.

Result on `main` and the current released `v1.44.2`: `Input.getTracks()` throws `UnsupportedInputFormatError` for a perfectly readable file.

## Repro

```ts
import { Input, UrlSource, HLS_FORMATS } from 'mediabunny';

const PLAYLIST = 'https://vod-adaptive-ak.vimeocdn.com/.../media.m3u8?...'; // Vimeo CDN, any clip
const input = new Input({
    source: new UrlSource(PLAYLIST, { requestInit: { credentials: 'omit' } }),
    formats: HLS_FORMATS,
});
console.log('canRead:', await input.canRead()); // true (HLS playlist itself is fine)
await input.getTracks();                         // UnsupportedInputFormatError
```

Stack:

```
UnsupportedInputFormatError: Input has an unsupported or unrecognizable format.
    at Input._getDemuxer (src/input.ts:165)
    at Input._getTrackBackings (src/input.ts:324)
    at Input.getTracks (src/input.ts:266)
    at HlsSegmentedInput.getInputForSegment (src/hls/hls-segmented-input.ts:543)
```

## Diagnosis

The HLS demuxer constructs a nested `Input` for the first media segment and probes its format. The segment's first 8 bytes:

```
00 00 00 34 73 69 64 78   //  size = 52, four-cc = 'sidx'
                          //  followed by moof, mdat
```

`Mp4InputFormat._canReadInput` ([`src/input-format.ts:113-124`](https://github.com/Vanilagy/mediabunny/blob/main/src/input-format.ts#L113-L124)):

```ts
async _canReadInput(input: Input) {
    const majorBrand = await this._getMajorBrand(input);
    if (majorBrand !== null) {
        return majorBrand !== 'qt  ';
    }
    let slice = input._reader.requestSlice(4, 4);
    if (slice instanceof Promise) slice = await slice;
    if (!slice) return false;

    return readAscii(slice, 4) === 'moof'; // Seen in HLS for example
}
```

`_getMajorBrand` returns `null` (no `ftyp/styp` at offset 4); the second branch only accepts `moof`, so `sidx` is rejected and no format claims the input.

The combination is valid per ISO/IEC 14496-12 — `sidx` is a top-level box, and the DASH-IF on-demand profile mandates a per-representation `sidx` placed before the fragments. HLS playlists that point at the same files (Vimeo's `vod-adaptive-ak.vimeocdn.com` CDN, Wistia, several CMAF-only Mux outputs) inherit that ordering.

### Proof that the segment is structurally fine

When the EXT-X-MAP init segment (`ftyp + moov`) and the media segment (`sidx + moof + mdat`) are concatenated and fed to Mediabunny as a single MP4 input (no HLS), Mediabunny demuxes it cleanly:

```
canRead: true
tracks: 1
  - video codec=avc, 3840x2160
duration: 6.07 s
```

So the bug is strictly in the format probe; the demuxer downstream handles the contents correctly once it gets a chance to run.

## Change

```diff
-    return readAscii(slice, 4) === 'moof'; // Seen in HLS for example
+    const fourCc = readAscii(slice, 4);
+    return fourCc === 'moof' || fourCc === 'sidx'; // Seen in HLS for example
```

Mirrors the existing `moof` line and matches the project's style.

## Test

Added `Mp4InputFormat recognises a CMAF segment that starts with sidx` to `test/node/hls-input.test.ts`. Fails on `main`, passes with the change:

```ts
test.concurrent('Mp4InputFormat recognises a CMAF segment that starts with sidx', async () => {
    const bytes = new Uint8Array(12);
    new DataView(bytes.buffer).setUint32(0, 60); // box size
    bytes.set([0x73, 0x69, 0x64, 0x78], 4); // 'sidx'

    using input = new Input({
        source: new BufferSource(bytes),
        formats: ALL_FORMATS,
    });

    expect(await input.canRead()).toBe(true);
    expect(await input.getFormat()).toBe(MP4);
});
```

## Verification

- `npm run lint` — clean
- `npx vitest run test/node/hls-input.test.ts` — passes (new test + all pre-existing HLS tests)
- Other test failures observed in a full-suite run are pre-existing `Cannot find module '@mediabunny/aac-encoder'` / `@mediabunny/ac3` / `@mediabunny/flac-encoder` / `@mediabunny/mp3-encoder` errors from missing optional extension packages — unrelated to this change

End-to-end against the original failing stream (Vimeo CDN HLS, 4K H.264, 2-minute clip):

| | before | after |
|---|---|---|
| `await input.canRead()` | `true` | `true` |
| `await input.getTracks()` | throws `UnsupportedInputFormatError` | resolves: `[ avc 3840x2160 ]` |
| `Conversion.execute()` | n/a | 305 MB MP4 written in 16.8 s |
| `Mp4OutputFormat({ fastStart: false })` moof count in output | n/a | 0 |

Regression-checked against `test/node/hls-input.test.ts` HLS-TS corpus (Big Buck Bunny `x36xhzz`, `test_001` AES-128) — all continue to pass.

## Notes

- Targeted change — no behaviour difference for inputs that already had a recognised `ftyp`/`styp`/`moof` at the start.
- Reuses `readAscii(slice, 4)` once via a local instead of calling it twice (small readability win).
- No new public API; no docs change needed.
