### PR TITLE
fix: add integer validation to isU32 utility function

### DIFF
--- a/src/misc.ts
+++ b/src/misc.ts
@@ -38,7 +38,7 @@ export const last = <T>(arr: T[]) => {
 };
 
 export const isU32 = (value: number) => {
-	return value >= 0 && value < 2 ** 32;
+	return Number.isInteger(value) && value >= 0 && value < 2 ** 32;
 };
 
 /** Reads an exponential-Golomb universal code from a Bitstream.  */

--- a/test/node/isU32.test.ts
+++ b/test/node/isU32.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { isU32 } from '../../src/misc';
+
+describe('isU32() function', () => {
+	it('should return true for valid unsigned 32-bit integers', () => {
+		expect(isU32(0)).toBe(true);
+		expect(isU32(1)).toBe(true);
+		expect(isU32(2147483647)).toBe(true); // 2^31 - 1
+		expect(isU32(2147483648)).toBe(true); // 2^31
+		expect(isU32(4294967295)).toBe(true); // 2^32 - 1
+	});
+
+	it('should return false for negative numbers', () => {
+		expect(isU32(-1)).toBe(false);
+		expect(isU32(-100)).toBe(false);
+	});
+
+	it('should return false for numbers >= 2^32', () => {
+		// Bug: The function checks `value < 2 ** 32` but should check `value <= 2 ** 32 - 1`
+		// or equivalently `value < 2 ** 32` is correct, but we need to ensure it's an integer
+		expect(isU32(4294967296)).toBe(false); // 2^32 exactly
+		expect(isU32(4294967297)).toBe(false); // 2^32 + 1
+	});
+
+	it('should handle floating point numbers', () => {
+		// The function should reject non-integer values
+		expect(isU32(1.5)).toBe(false);
+		expect(isU32(100.7)).toBe(false);
+		expect(isU32(0.1)).toBe(false);
+	});
+
+	it('should handle edge case of exactly 2^32', () => {
+		expect(isU32(4294967296)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- The `isU32()` function in `src/misc.ts` was missing integer validation, allowing floating-point numbers to pass as valid unsigned 32-bit integers
- Added `Number.isInteger()` check to ensure only actual integers are accepted
- Added unit tests covering edge cases: valid u32 values, negative numbers, boundary values, and floating-point rejection

## Test plan
- [x] Added `test/node/isU32.test.ts` with comprehensive test coverage
- [x] All existing tests pass
- [x] New tests confirm the fix handles floating-point inputs correctly

## Impact
This bug could cause subtle issues in binary parsing contexts where `isU32()` is used for input validation. Floating-point values would incorrectly pass validation, potentially leading to data corruption or unexpected behavior.