### PR TITLE
Fix ID3v2 metadata parser

### DIFF
--- a/src/id3.ts
+++ b/src/id3.ts
@@ -488,7 +488,7 @@ export class Id3V2Reader {
 
 	readU24() {
 		const high = this.view.getUint16(this.pos, false);
-		const low = this.view.getUint8(this.pos + 1);
+		const low = this.view.getUint8(this.pos + 2);
 		this.pos += 3;
 		return high * 0x100 + low;
 	}


### PR DESCRIPTION
Off by one error.


Noticed when trying to parse the metadata of this mp3 with `input.getMetadataTags()`
[Metalmania.mp3](https://github.com/user-attachments/files/27756885/Metalmania.mp3)

"Metalmania" Kevin MacLeod (incompetech.com)
Licensed under Creative Commons: By Attribution 4.0 License
http://creativecommons.org/licenses/by/4.0/
