### PR TITLE
Fix MediaStreamTrackProcessor worker support handshake

### DIFF
--- a/src/media-source.ts
+++ b/src/media-source.ts
@@ -2941,6 +2941,8 @@ type MediaStreamTrackProcessorWorkerMessage = {
 };
 
 type MediaStreamTrackProcessorControllerMessage = {
+	type: 'support';
+} | {
 	type: 'videoTrack';
 	trackId: number;
 	track: MediaStreamVideoTrack;
@@ -2958,12 +2960,6 @@ const mediaStreamTrackProcessorWorkerCode = () => {
 		}
 	};
 
-	// Immediately send a message to the main thread, letting them know of the support
-	sendMessage({
-		type: 'support',
-		supported: typeof MediaStreamTrackProcessor !== 'undefined',
-	});
-
 	const abortControllers = new Map<number, AbortController>();
 	const activeTracks = new Map<number, MediaStreamVideoTrack>();
 
@@ -2971,6 +2967,13 @@ const mediaStreamTrackProcessorWorkerCode = () => {
 		const message = event.data as MediaStreamTrackProcessorControllerMessage;
 
 		switch (message.type) {
+			case 'support': {
+				sendMessage({
+					type: 'support',
+					supported: typeof MediaStreamTrackProcessor !== 'undefined',
+				});
+			}; break;
+
 			case 'videoTrack': {
 				activeTracks.set(message.trackId, message.track);
 
@@ -3068,6 +3071,7 @@ const mediaStreamTrackProcessorIsSupportedInWorker = async () => {
 		};
 
 		mediaStreamTrackProcessorWorker.addEventListener('message', listener);
+		mediaStreamTrackProcessorWorker.postMessage({ type: 'support' });
 	});
 };
 


### PR DESCRIPTION
## Summary
- Fixes a race in the `MediaStreamTrackProcessor` worker-support probe used by `MediaStreamVideoTrackSource`.
- Changes the helper worker handshake from an immediate startup message to an explicit request/response after the main thread listener is registered.
- Prevents `mediaStreamTrackProcessorIsSupportedInWorker()` from hanging if the worker posts its support result before the caller starts listening.

## Bug
When `MediaStreamTrackProcessor` is unavailable on the main thread, `MediaStreamVideoTrackSource._start()` checks whether it is available inside a helper worker. The worker currently posts its `{ type: 'support' }` response immediately when it starts.

The main thread creates the worker first and only then attaches the `message` listener inside `mediaStreamTrackProcessorIsSupportedInWorker()`. If the worker starts quickly enough, the support message can be sent before that listener exists. In that case the promise returned by `mediaStreamTrackProcessorIsSupportedInWorker()` never resolves, so `MediaStreamVideoTrackSource._start()` never resolves, and `Output.start()` can stay pending forever.

We hit this in a production Next/Turbopack browser bundle while starting a WebCodecs recording: the recorder remained in its startup state because `Output.start()` never settled.

## Fix
The worker now handles an explicit `{ type: 'support' }` controller message. The main thread registers the listener first, then sends that request. This keeps the existing support cache and worker fallback behavior, but removes the startup-message race.

## Test plan
- npm run check

🤖 Generated with [Codex](https://Codex.com/Codex)