### PR TITLE
Add blog post about video dimensions

### DIFF
--- a/dev/leak.html
+++ b/dev/leak.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<p id="progress"></p>
+<input type="file" id="file-input" multiple>
+
+<script type="module">
+	const progress = document.getElementById('progress');
+	const fileInput = document.getElementById('file-input');
+
+	const worker = new Worker(new URL('./leak.worker.js', import.meta.url), { type: 'module' });
+
+	let pendingResolve = null;
+	worker.onmessage = (e) => {
+		if (e.data.type === 'done') {
+			pendingResolve?.();
+			pendingResolve = null;
+		} else if (e.data.type === 'error') {
+			pendingResolve?.(e.data.message);
+			pendingResolve = null;
+		}
+	};
+
+	const processFile = (file) => {
+		return new Promise((resolve, reject) => {
+			pendingResolve = (err) => {
+				if (err) reject(new Error(err));
+				else resolve();
+			};
+			worker.postMessage({ type: 'loadFile', file });
+		});
+	};
+
+	fileInput.addEventListener('change', async () => {
+		const files = fileInput.files;
+		fileInput.disabled = true;
+		try {
+			for (let i = 0; i < files.length; i++) {
+				const file = files[i];
+				progress.textContent = `Processing ${i + 1} / ${files.length}: ${file.name}`;
+				await processFile(file);
+			}
+			progress.textContent = `Done - processed ${files.length} file(s). Check Worker memory in DevTools.`;
+			fileInput.value = '';
+		} finally {
+			fileInput.disabled = false;
+		}
+	});
+</script>

--- a/dev/leak.worker.js
+++ b/dev/leak.worker.js
@@ -1,0 +1,137 @@
+import {
+	ALL_FORMATS,
+	AudioSampleSink,
+	Input,
+	StreamSource,
+} from '../dist/bundles/mediabunny.mjs';
+
+/**
+ * Repro for the mediabunny 1.42.0 memory leak.
+ *
+ * Root cause: the `StreamSource` read callback closes over `this.reader`, which
+ * stores the resolved `InputAudioTrack`. `InputAudioTrack.input` is a strong
+ * back-reference to `Input`, completing the cycle:
+ *
+ *   FinalizationRegistry (live GC root)
+ *     -> _sourceRefs: SourceRef[]           (held value, held strongly)
+ *     -> SourceRef.source: StreamSource
+ *     -> read callback closure
+ *     -> reader.track: InputAudioTrack
+ *     -> InputAudioTrack.input: Input        <- registry target
+ *
+ * The held value reaches the target, so the target is never unreachable.
+ * The registry never fires. `Input.dispose()` is never called.
+ * `ReadOrchestrator.cache` (~8 MiB per file) is retained permanently.
+ *
+ * Steps to observe:
+ *   1. Open DevTools -> Memory, select the Worker context.
+ *   2. Select 5+ audio files and click Choose File(s).
+ *   3. Take a heap snapshot. Observe JSArrayBufferData growth (~8 MiB per file).
+ *   4. Click "Collect garbage" - memory does not drop.
+ *
+ * Workaround: call `input.dispose()` before MbFrameSource.init() returns and
+ * repeat test. Memory usage would recover. Not easy to know when it should be called
+ * in the full implementation, so best if we can rely on normal GC.
+ */
+
+// Mockup of our custom reader.
+class BlobBinaryReader {
+	constructor(src) {
+		this.src = src;
+	}
+
+	async read(start, end) {
+		return new Uint8Array(await this.src.slice(start, end).arrayBuffer());
+	}
+
+	async byteLength() {
+		return this.src.size;
+	}
+}
+
+class MbFrameSource {
+	static async create(reader) {
+		const fs = new MbFrameSource(reader);
+		await fs.init();
+		return fs;
+	}
+
+	get track() {
+		return this._track;
+	}
+
+	constructor(sourceReader) {
+		this._track = null;
+		this.reader = sourceReader;
+	}
+
+	async init() {
+		const source = new StreamSource({
+			prefetchProfile: 'fileSystem',
+			read: (start, end) => this.reader.read(start, end),
+			getSize: () => this.reader.byteLength(),
+		});
+
+		const input = new Input({
+			source: source,
+			formats: ALL_FORMATS,
+		});
+
+		// Assigning back to reader.track closes the cycle through the
+		// FinalizationRegistry's held value, preventing Input from ever being
+		// considered unreachable. ~8 MiB of ReadOrchestrator.cache leaks here.
+		this._track = await input.getPrimaryAudioTrack();
+
+		// Uncomment to get it to work.
+		// input.dispose();
+	}
+}
+
+// Mockup of our clip.
+class MbAudClip {
+	static async create(frameSource) {
+		const clip = new MbAudClip();
+		await clip.init(frameSource);
+		return clip;
+	}
+
+	constructor() {
+		this.sampleSink = undefined;
+	}
+
+	async init(frameSource) {
+		const audioTrack = frameSource.track;
+		if (!audioTrack) {
+			throw new Error('Could not get audio track.');
+		}
+		this.sampleSink = new AudioSampleSink(audioTrack);
+	}
+
+	async play() {
+		if (!this.sampleSink) {
+			throw new Error('Attempting to play without initializing.');
+		}
+
+		// This is where playing would happen, but not needed to demo the issue.
+	}
+}
+
+const loadFile = async (file) => {
+	const reader = new BlobBinaryReader(new Blob([file], { type: file.type }));
+	const frameSource = await MbFrameSource.create(reader);
+	const clip = await MbAudClip.create(frameSource);
+
+	await clip.play();
+};
+
+self.onmessage = (e) => {
+	if (e.data.type === 'loadFile') {
+		loadFile(e.data.file)
+			.then(() => {
+				self.postMessage({ type: 'done' });
+			})
+			.catch((err) => {
+				self.postMessage({ type: 'error', message: String(err) });
+			});
+	}
+};

--- a/docs/blog.data.ts
+++ b/docs/blog.data.ts
@@ -1,7 +1,16 @@
-import { createContentLoader } from 'vitepress';
+import { createContentLoader, type ContentData } from 'vitepress';
+
+const getPublishedOnTimestamp = (post: ContentData) => {
+	const frontmatter = post.frontmatter as Record<string, unknown>;
+	const publishedOnIso = frontmatter['publishedOnIso'];
+
+	return typeof publishedOnIso === 'string'
+		? Date.parse(publishedOnIso)
+		: 0;
+};
 
 export default createContentLoader('blog/*.md', {
 	transform: posts => posts.sort((a, b) =>
-		Date.parse(b.frontmatter.publishedOnIso) - Date.parse(a.frontmatter.publishedOnIso)
+		getPublishedOnTimestamp(b) - getPublishedOnTimestamp(a),
 	),
 });

--- a/docs/blog.data.ts
+++ b/docs/blog.data.ts
@@ -1,3 +1,7 @@
 import { createContentLoader } from 'vitepress';
 
-export default createContentLoader('blog/*.md');
+export default createContentLoader('blog/*.md', {
+	transform: posts => posts.sort((a, b) =>
+		Date.parse(b.frontmatter.publishedOnIso) - Date.parse(a.frontmatter.publishedOnIso)
+	),
+});

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -14,7 +14,22 @@ import BlogAuthor from './components/BlogAuthor.vue';
 <template v-for="(post, i) in data">
 	<a :href="post.url" class="flex flex-col sm:flex-row items-start sm:gap-8 !text-inherit !no-underline ![font-weight:inherit] group">
 		<div>
-			<img src="./assets/on-air.png" class="shrink-0 sm:w-40 rounded" />
+			<img
+				v-if="post.frontmatter.thumbnail"
+				:src="post.frontmatter.thumbnail"
+				:alt="post.frontmatter.title"
+				width="160"
+				height="90"
+				class="shrink-0 sm:w-40 rounded"
+			/>
+			<img
+				v-else
+				src="./assets/on-air.png"
+				:alt="post.frontmatter.title"
+				width="160"
+				height="80"
+				class="shrink-0 sm:w-40 rounded"
+			/>
 			<div v-if="false" class="p-1">
 				<BlogAuthor :frontmatter="post.frontmatter" small />
 			</div>

--- a/docs/blog/video-dimensions-can-lie.md
+++ b/docs/blog/video-dimensions-can-lie.md
@@ -1,0 +1,198 @@
+---
+title: Why video dimensions can lie
+description: "What I learned building vertical video feeds: width and height alone are not enough to choose the right fit behavior."
+publishedOn: May 24, 2026
+publishedOnIso: "2026-05-24"
+author: Hirbod Mirjavadi
+authorImage: https://github.com/hirbod.png
+authorLink: https://github.com/hirbod
+authorSubtitle: Creator of expo-video-metadata
+thumbnail: /blog/video-dimensions-can-lie.svg
+excerpt: "In vertical video feeds, choosing between cover and contain looks like a simple aspect-ratio check. Then rotation metadata shows up, and width and height stop telling the full story."
+---
+
+<script setup>
+import BlogAuthor from '../components/BlogAuthor.vue';
+</script>
+
+<img :src="$frontmatter.thumbnail" width="640" height="360" alt="A coded portrait video frame rotated into a landscape display frame" class="rounded-2xl mb-2">
+
+<p class="!m-0 opacity-70">{{ $frontmatter.publishedOn }}</p>
+
+<h1>{{ $frontmatter.title }}</h1>
+
+<BlogAuthor />
+
+After building a few vertical video apps, I expected the painful parts to be compression, downscaling, bitrate, and upload speed. Those are real problems. But the thing that wasted a surprising amount of my time was much smaller: deciding how a video should fit inside the player.
+
+In a vertical feed, some videos should fill the screen. Others should be shown fully, even if that means letterboxing. My first version was exactly what you would expect:
+
+```ts
+function chooseObjectFit(width: number, height: number) {
+	if (height > width) {
+		return 'cover';
+	}
+
+	return 'contain';
+}
+```
+
+Then the logic got a little more careful. Square and near-square videos usually shouldn't be cropped aggressively, because too much useful content can disappear. So only videos that were clearly portrait should use `cover`; everything else should use `contain`:
+
+```ts
+function chooseFeedFit(width: number, height: number) {
+	const aspectRatio = width / height;
+
+	if (height > width && aspectRatio <= 0.8) {
+		return 'cover';
+	}
+
+	return 'contain';
+}
+```
+
+That seemed good enough. It was not.
+
+## The bug that didn't look like one
+
+The bug showed up as videos that were clearly landscape, but the app treated them like portrait videos. The annoying part was that the numbers seemed to agree with the app. The stored width and height said the video was taller than it was wide.
+
+So we checked the upload pipeline. We checked the player. We checked the database values. We changed the thresholds. None of that fixed it.
+
+The missing piece was rotation metadata.
+
+Video files can store frames one way, then describe how those frames should be presented. A file can have coded frames that are 1080x1920, but also say: rotate this by 90 degrees when displaying it. Depending on which values the app reads, the same file can look portrait in one part of the system and landscape in another.
+
+That distinction matters:
+
+```ts
+const video = {
+	codedWidth: 1080,
+	codedHeight: 1920,
+	rotation: 90,
+	displayWidth: 1920,
+	displayHeight: 1080,
+};
+```
+
+If your app only looks at `codedWidth` and `codedHeight`, it sees a portrait video. If the player applies the rotation during playback, the user sees a landscape video. That's how you end up with the wrong `objectFit` even though every individual value looks "correct."
+
+## Coded size is not display size
+
+The practical lesson is simple: a video can have more than one size.
+
+- `codedWidth` and `codedHeight` tell you how the frames are stored.
+- `rotation` tells you how those frames should be presented.
+- `displayWidth` and `displayHeight` tell you what shape the user actually sees.
+
+For a feed UI, `displayWidth` and `displayHeight` are the values you usually want. They answer the question the player actually cares about: what shape is this video on screen?
+
+So the fit logic should use display dimensions, not raw coded dimensions:
+
+```ts
+type VideoDisplayMetadata = {
+	displayWidth: number;
+	displayHeight: number;
+};
+
+function chooseFeedFit(metadata: VideoDisplayMetadata) {
+	const aspectRatio = metadata.displayWidth / metadata.displayHeight;
+
+	if (metadata.displayHeight > metadata.displayWidth && aspectRatio <= 0.8) {
+		return 'cover';
+	}
+
+	return 'contain';
+}
+```
+
+The threshold can be whatever makes sense for your product. The important part is where the ratio comes from. It should be calculated from the dimensions after presentation metadata has been applied.
+
+## Extract the metadata before playback
+
+I also don't think this should be figured out over and over again inside every video player instance. By the time someone scrolls to a video, the app should already know how that asset should be rendered.
+
+A much cleaner flow is:
+
+1. Read the video metadata during upload or ingestion.
+2. Store the display dimensions, coded dimensions, rotation, and other useful technical metadata with the asset.
+3. Use those stored values when rendering the feed.
+
+This does not have to happen in the browser. If your upload already goes through a backend, Mediabunny can run there too via [`@mediabunny/server`](../guide/extensions/server), so you can extract the same metadata in Node, Bun, or Deno as part of your ingestion pipeline.
+
+That keeps the player simple, and it makes the behavior consistent across clients. You're no longer relying on each platform to expose the same playback metadata in the same way at the same time.
+
+## Mediabunny gives you the missing values
+
+This is one of the reasons I like [Mediabunny](https://mediabunny.dev/). It exposes the video track values you need directly: coded dimensions, display dimensions, and rotation. The display dimensions also account for pixel aspect ratio, which is another detail I don't want UI code to rediscover.
+
+```ts
+import { ALL_FORMATS, BlobSource, Input } from 'mediabunny';
+
+export async function readVideoDisplayMetadata(file: File) {
+	const input = new Input({
+		source: new BlobSource(file),
+		formats: ALL_FORMATS,
+	});
+
+	const videoTrack = await input.getPrimaryVideoTrack();
+	if (!videoTrack) {
+		return null;
+	}
+
+	const [
+		codedWidth,
+		codedHeight,
+		displayWidth,
+		displayHeight,
+		rotation,
+	] = await Promise.all([
+		videoTrack.getCodedWidth(),
+		videoTrack.getCodedHeight(),
+		videoTrack.getDisplayWidth(),
+		videoTrack.getDisplayHeight(),
+		videoTrack.getRotation(),
+	]);
+
+	return {
+		codedWidth,
+		codedHeight,
+		displayWidth,
+		displayHeight,
+		rotation,
+	};
+}
+```
+
+It's not a lot of data, but it removes a lot of guessing.
+
+## Expo apps can use the same idea
+
+For Expo and React Native apps, I built [expo-video-metadata](https://github.com/hirbod/expo-video-metadata) around this exact problem. It uses Mediabunny to expose video metadata across iOS, Android, and web, so you can collect these values during upload before the asset ever appears in a feed.
+
+```ts
+import { getVideoInfoAsync } from 'expo-video-metadata';
+
+const info = await getVideoInfoAsync(videoUri);
+const primaryVideoTrack = info.tracks.find((track) => track.type === 'video');
+
+if (primaryVideoTrack?.type === 'video') {
+	const fit = chooseFeedFit({
+		displayWidth: primaryVideoTrack.displayWidth,
+		displayHeight: primaryVideoTrack.displayHeight,
+	});
+
+	// Store `fit`, display dimensions, coded dimensions, and rotation
+	// with the uploaded asset metadata.
+}
+```
+
+Once this is stored, rendering becomes boring in the best way. The feed reads the asset metadata, decides the fit mode, and passes it to the player.
+
+## The lesson
+
+For vertical video apps, "is this video portrait?" is not the same question as "is height greater than width?"
+
+The better question is: after presentation metadata is applied, what shape does the user actually see?
+
+If you answer that during upload and store the result, `objectFit` stops being a runtime guess. Mediabunny gives you the low-level video facts you need, and `expo-video-metadata` makes those facts easy to use in Expo apps.

--- a/docs/components/BlogAuthor.vue
+++ b/docs/components/BlogAuthor.vue
@@ -9,11 +9,20 @@ const props = defineProps<{
 
 const data = useData();
 const frontmatter = computed(() => props.frontmatter ?? data.frontmatter.value);
+const imageSize = computed(() => props.small ? 32 : 40);
 </script>
 
 <template>
 	<a :href="frontmatter['authorLink']" class="inline-flex gap-2 items-center !no-underline !text-(--var-c-text-1) py-1">
-		<img :src="frontmatter['authorImage']" class="size-10 rounded-full shadow" :class="{ '!size-8': small }" />
+		<img
+			:src="frontmatter['authorImage']"
+			:alt="`${frontmatter['author']} avatar`"
+			:width="imageSize"
+			:height="imageSize"
+			decoding="async"
+			class="size-10 shrink-0 rounded-full shadow object-cover"
+			:class="{ '!size-8': small }"
+		/>
 		<div class="pl-1">
 			<p class="!m-0 font-semibold" :class="{ 'text-sm': small }">{{ frontmatter['author'] }}</p>
 			<!--

--- a/docs/public/blog/video-dimensions-can-lie.svg
+++ b/docs/public/blog/video-dimensions-can-lie.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+	<title id="title">Coded video dimensions rotated into display dimensions</title>
+	<desc id="desc">A portrait coded frame turns into a landscape display frame after rotation metadata is applied.</desc>
+	<defs>
+		<linearGradient id="background" x1="0" x2="1" y1="0" y2="1">
+			<stop offset="0%" stop-color="#18181b" />
+			<stop offset="58%" stop-color="#27272a" />
+			<stop offset="100%" stop-color="#0f766e" />
+		</linearGradient>
+		<linearGradient id="screenA" x1="0" x2="1" y1="0" y2="1">
+			<stop offset="0%" stop-color="#475569" />
+			<stop offset="100%" stop-color="#1e293b" />
+		</linearGradient>
+		<linearGradient id="screenB" x1="0" x2="1" y1="0" y2="1">
+			<stop offset="0%" stop-color="#0f172a" />
+			<stop offset="100%" stop-color="#111827" />
+		</linearGradient>
+		<filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
+			<feDropShadow dx="0" dy="14" stdDeviation="13" flood-color="#000" flood-opacity="0.34" />
+		</filter>
+	</defs>
+
+	<rect width="640" height="360" rx="32" fill="url(#background)" />
+	<path d="M0 287 C120 226 218 300 342 244 C472 185 523 226 640 168 L640 360 L0 360 Z" fill="#14b8a6" opacity="0.15" />
+	<g stroke="#a1a1aa" stroke-width="2" stroke-linecap="round" opacity="0.2">
+		<path d="M72 92 H568" />
+		<path d="M72 264 H568" />
+	</g>
+
+	<text x="320" y="58" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="30" font-weight="800" fill="#ffffff">Coded vs display size</text>
+
+	<g filter="url(#shadow)">
+		<rect x="134" y="116" width="100" height="126" rx="20" fill="#f4f4f5" />
+		<rect x="144" y="126" width="80" height="106" rx="15" fill="#111827" />
+		<rect x="158" y="142" width="52" height="74" rx="10" fill="url(#screenA)" />
+		<path d="M166 200 L183 177 L195 193 L207 174 L216 200 Z" fill="#67e8f9" />
+		<circle cx="201" cy="155" r="9" fill="#facc15" />
+	</g>
+
+	<text x="184" y="297" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="700" fill="#fafafa">1080 x 1920</text>
+	<text x="184" y="320" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#cbd5e1">coded frame</text>
+
+	<g filter="url(#shadow)">
+		<rect x="402" y="143" width="154" height="90" rx="22" fill="#f4f4f5" />
+		<rect x="416" y="156" width="126" height="64" rx="13" fill="url(#screenB)" />
+		<path d="M429 204 L464 178 L491 197 L512 176 L542 204 Z" fill="#5eead4" />
+		<circle cx="512" cy="172" r="10" fill="#facc15" />
+	</g>
+
+	<path d="M286 180 C302 146 333 146 348 164" fill="none" stroke="#facc15" stroke-width="8" stroke-linecap="round" />
+	<path d="M362 178 L340 168 L354 154 Z" fill="#facc15" />
+	<rect x="288" y="199" width="68" height="28" rx="14" fill="#18181b" opacity="0.82" />
+	<text x="322" y="219" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" font-weight="800" fill="#facc15">90deg</text>
+
+	<text x="479" y="297" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="700" fill="#fafafa">1920 x 1080</text>
+	<text x="479" y="320" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="15" fill="#cbd5e1">display frame</text>
+</svg>


### PR DESCRIPTION
This adds a guest blog post about a video metadata issue I ran into while building vertical feeds: width and height alone can be misleading when rotation metadata is involved. The post walks through the original object-fit heuristic, why it broke, and how Mediabunny exposes the display dimensions and rotation values needed to make that decision reliably.

I also added a small thumbnail for the post, made the blog index use per-post thumbnails, sorted posts by publish date, and reserved author avatar dimensions to avoid layout shift with external images.

Checked locally with `npm run docs:build`.


https://github.com/user-attachments/assets/6155bfd2-059b-43f0-a7b0-d8d361b921b2

