### PR TITLE
Document UrlSource RequestInit overrides

### DIFF
--- a/docs/guide/reading-media-files.md
+++ b/docs/guide/reading-media-files.md
@@ -643,6 +643,8 @@ const source = new UrlSource('https://example.com/bigbuckbunny.mp4', {
 });
 ```
 
+All `requestInit` fields are respected except for `signal` and `headers.Range`, which are overridden by Mediabunny. The same applies to the `signal` and `headers.Range` values of a `Request` passed as the first constructor argument. To cancel ongoing requests, [dispose of the input](#disposing-inputs).
+
 `getRetryDelay` can be used to control the retry logic used should a request fail. When a request fails, `getRetryDelay` should return the time to wait in seconds before the request will be retried. Returning `null` prevents further retries.
 ```ts
 // UrlSource using retry logic with exponential backoff:


### PR DESCRIPTION
## Summary
- Clarify in the Reading media files guide that `UrlSource` does not treat `requestInit` as a complete Fetch API pass-through.
- Document that Mediabunny overrides `signal` and `headers.Range` for both `requestInit` and `Request` inputs.
- Point readers to `Input.dispose` for canceling ongoing requests.

## Reasoning
The API docs already mention these overrides, but the higher-level Reading media files guide did not. Since users are likely to configure `UrlSource` from this guide, it should be clear there that `signal` and `Range` cannot be supplied through `RequestInit`/`Request` in the usual way.

## Testing
- Started the VitePress docs dev server locally and verified it runs.
