### PR TITLE
Fix tkhd issue for Apple ecosystem compatibility

### DIFF
--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -378,12 +378,26 @@ export const free = (size: number): Box => ({ type: 'free', size });
  * Movie Box: Used to specify the information that defines a movie - that is, the information that allows
  * an application to interpret the sample data that is stored elsewhere.
  */
-export const moov = (muxer: IsobmffMuxer) => box('moov', undefined, [
-	mvhd(muxer.creationTime, muxer.trackDatas),
-	...muxer.trackDatas.map(x => trak(x, muxer.creationTime)),
-	muxer.isFragmented ? mvex(muxer.trackDatas) : null,
-	udta(muxer),
-]);
+export const moov = (muxer: IsobmffMuxer) => {
+	// FFmpeg-aligned fallback: If no track of a given type is enabled, force the first one to be enabled.
+	// This ensures compatibility with strict players like QuickTime.
+	for (const type of ['video', 'audio', 'subtitle'] as const) {
+		const tracks = muxer.trackDatas.filter(t => t.type === type);
+		const hasEnabled = tracks.some(t => t.track.metadata.disposition?.default !== false);
+		if (!hasEnabled && tracks.length > 0) {
+			const firstTrack = tracks[0]!;
+			if (!firstTrack.track.metadata.disposition) firstTrack.track.metadata.disposition = {};
+			firstTrack.track.metadata.disposition.default = true;
+		}
+	}
+
+	return box('moov', undefined, [
+		mvhd(muxer.creationTime, muxer.trackDatas),
+		...muxer.trackDatas.map(x => trak(x, muxer.creationTime)),
+		muxer.isFragmented ? mvex(muxer.trackDatas) : null,
+		udta(muxer),
+	]);
+};
 
 /** Movie Header Box: Used to specify the characteristics of the entire movie, such as timescale and duration. */
 export const mvhd = (

--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -379,18 +379,6 @@ export const free = (size: number): Box => ({ type: 'free', size });
  * an application to interpret the sample data that is stored elsewhere.
  */
 export const moov = (muxer: IsobmffMuxer) => {
-	// FFmpeg-aligned fallback: If no track of a given type is enabled, force the first one to be enabled.
-	// This ensures compatibility with strict players like QuickTime.
-	for (const type of ['video', 'audio', 'subtitle'] as const) {
-		const tracks = muxer.trackDatas.filter(t => t.type === type);
-		const hasEnabled = tracks.some(t => t.track.metadata.disposition?.default !== false);
-		if (!hasEnabled && tracks.length > 0) {
-			const firstTrack = tracks[0]!;
-			if (!firstTrack.track.metadata.disposition) firstTrack.track.metadata.disposition = {};
-			firstTrack.track.metadata.disposition.default = true;
-		}
-	}
-
 	return box('moov', undefined, [
 		mvhd(muxer.creationTime, muxer.trackDatas),
 		...muxer.trackDatas.map(x => trak(x, muxer.creationTime)),

--- a/src/isobmff/isobmff-muxer.ts
+++ b/src/isobmff/isobmff-muxer.ts
@@ -22,7 +22,7 @@ import {
 	vtte,
 } from './isobmff-boxes';
 import { Muxer } from '../muxer';
-import { Output, OutputAudioTrack, OutputSubtitleTrack, OutputTrack, OutputVideoTrack } from '../output';
+import { Output, OutputAudioTrack, OutputSubtitleTrack, OutputTrack, OutputVideoTrack, TrackType } from '../output';
 import { Writer } from '../writer';
 import { BufferTarget } from '../target';
 import { assert, computeRationalApproximation, last, promiseWithResolvers, Rational, simplifyRational } from '../misc';
@@ -1183,6 +1183,8 @@ export class IsobmffMuxer extends Muxer {
 				boxWriter.writer.startTrackingWrites();
 			}
 
+			this.ensureOneEnabledTrack();
+
 			// Write the moov box now that we have all decoder configs
 			const movieBox = moov(this);
 			boxWriter.writeBox(movieBox);
@@ -1299,6 +1301,8 @@ export class IsobmffMuxer extends Muxer {
 
 		if (this.allTracksAreKnown()) {
 			if (!this.mdat) {
+				this.ensureOneEnabledTrack();
+
 				// We finally know all tracks, let's reserve space for the moov box
 				const moovBox = moov(this);
 				const moovSize = this.boxWriter.measureBox(moovBox);
@@ -1389,11 +1393,34 @@ export class IsobmffMuxer extends Muxer {
 		release();
 	}
 
+	ensureOneEnabledTrack() {
+		// If no track of a given type is enabled, force the first one to be enabled. Otherwise the video won't play in
+		// players like QuickTime.
+		// https://github.com/Vanilagy/mediabunny/pull/391
+		for (const type of ['video', 'audio', 'subtitle'] as TrackType[]) {
+			const tracks = this.trackDatas.filter(t => t.type === type);
+			if (tracks.length === 0) {
+				continue;
+			}
+
+			const hasEnabled = tracks.some(t => t.track.metadata.disposition?.default !== false);
+			if (!hasEnabled) {
+				const firstTrack = tracks[0]!;
+
+				firstTrack.track.metadata.disposition = {
+					...firstTrack.track.metadata.disposition,
+					default: true,
+				};
+			}
+		}
+	}
+
 	/** Finalizes the file, making it ready for use. Must be called after all video and audio chunks have been added. */
 	async finalize() {
 		const release = await this.mutex.acquire();
 
 		this.allTracksKnown.resolve();
+		this.ensureOneEnabledTrack();
 
 		for (const trackData of this.trackDatas) {
 			trackData.closed = true;

--- a/test/node/isobmff-muxer.test.ts
+++ b/test/node/isobmff-muxer.test.ts
@@ -352,3 +352,38 @@ test('PCM audio, no silence padding with approximate timestamps', async () => {
 
 	expect(frameCount).toBe(expectedFrameCount);
 });
+
+// https://github.com/Vanilagy/mediabunny/pull/391
+test('At least one track is enabled even if all are added disabled', async () => {
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+
+	const meta = { decoderConfig: { codec: 'vp8', codedWidth: 1280, codedHeight: 720 } };
+
+	const source1 = new EncodedVideoPacketSource('vp8');
+	output.addVideoTrack(source1, { disposition: { default: false } });
+
+	const source2 = new EncodedVideoPacketSource('vp8');
+	output.addVideoTrack(source2, { disposition: { default: false } });
+
+	await output.start();
+
+	await source1.add(new EncodedPacket(new Uint8Array(1024), 'key', 0, 0.1), meta);
+	await source2.add(new EncodedPacket(new Uint8Array(1024), 'key', 0, 0.1), meta);
+
+	await output.finalize();
+
+	using input = new Input({
+		source: new BufferSource(output.target.buffer!),
+		formats: ALL_FORMATS,
+	});
+
+	const tracks = await input.getVideoTracks();
+	expect(tracks.length).toBe(2);
+
+	// Even though both tracks were added disabled, the muxer forces the first one to be enabled
+	expect((await tracks[0]!.getDisposition()).default).toBe(true);
+	expect((await tracks[1]!.getDisposition()).default).toBe(false);
+});


### PR DESCRIPTION
# PR: fix tkhd issue for Apple ecosystem compatibility (align with FFmpeg)

## Description

When remuxing from formats (like some MKV files) where no track explicitly has its `disposition.default` set to `true` (or when the metadata is omitted), `mediabunny` currently passes this state directly to the output. As a result, the generated MP4 file may have all its tracks disabled (`tkhd` box flags are set to `0x02` instead of `0x03`).

While some tolerant players ignore this, strict players—particularly within the **Apple ecosystem (QuickTime Player, iOS/macOS Safari)**—require at least one video/audio track to have the `Track_enabled` flag (`0x01`). If this flag is missing, the player will fail to render the video (black screen) or play the audio.

This PR introduces a robust fallback logic during the `moov` box generation. If no track of a specific media type (video, audio, or subtitle) is explicitly enabled, it forces the first track of that type to be enabled.

### FFmpeg Alignment

This approach perfectly aligns with how FFmpeg handles the same scenario. FFmpeg checks the enabled track counts per media type before finalizing the header and applies a similar fallback to guarantee output compatibility:

```c
// libavformat/movenc.c (FFmpeg Source)
// Count enabled tracks per media type during muxing:
int enabled[AVMEDIA_TYPE_NB] = { 0 };
int first[AVMEDIA_TYPE_NB];

// ... (track iterations omitted) ...

for (i = 0; i < AVMEDIA_TYPE_NB; i++) {
    // If no track of a given type is enabled, force the first one to be enabled.
    if (!enabled[i] && first[i] >= 0)
        mov->tracks[first[i]].flags |= MOV_TRACK_ENABLED;
}
```

## Changes Made
- Modified `moov` box generation in `src/isobmff/isobmff-boxes.ts`.
- Added a pre-processing loop that checks `disposition.default` across `trackDatas`.
- If no track within a given type has `default !== false`, we mutate the `disposition` of the first track of that type to explicitly set `default = true`.
- This ensures the `tkhd` box generation (which checks for `disposition.default !== false`) will correctly apply the `0x01` (`Track_enabled`) flag.

## Testing

I have built this change locally and tested it in a PWA Media Player project ([StringWeaver/Local-PWA-Media-Player](https://github.com/StringWeaver/Local-PWA-Media-Player.git)). 
The resulting MP4 output can now be successfully imported and played on QuickTime and Safari without throwing the typical black screen error caused by the previously disabled `tkhd` flags.