### PR TITLE
Add standalone single-file HLS MP4 mode

### DIFF
--- a/src/hls/hls-muxer.ts
+++ b/src/hls/hls-muxer.ts
@@ -32,6 +32,7 @@ import {
 	HlsOutputFormatOptions,
 	HlsOutputPlaylistInfo,
 	HlsOutputSegmentInfo,
+	Mp4OutputFormat,
 	OutputFormat,
 } from '../output-format';
 import { Writer } from '../writer';
@@ -66,6 +67,20 @@ type PlaylistSegment = {
 	info: HlsOutputSegmentInfo | null;
 };
 
+type StandaloneSingleFile = {
+	output: Output;
+	target: Target;
+	path: string;
+	info: HlsOutputSegmentInfo;
+	videoSources: Map<OutputTrack, EncodedVideoPacketSource>;
+	audioSources: Map<OutputTrack, EncodedAudioPacketSource>;
+	fragments: {
+		start: number;
+		end: number | null;
+		timestamp: number;
+	}[];
+};
+
 type Playlist = {
 	id: number;
 	path: string;
@@ -89,6 +104,12 @@ type Playlist = {
 		info: HlsOutputSegmentInfo;
 	} | null;
 
+	standaloneSingleFile: StandaloneSingleFile | null;
+	standaloneSegmentInfos: {
+		timestamp: number;
+		duration: number;
+	}[];
+
 	// For HLS, having a single mutex is too coarse. Every playlist is basically independent and therefore we can have
 	// a per-playlist mutex instead of a per-muxer one. This means two packets from different playlists coming in don't
 	// block each other.
@@ -111,6 +132,7 @@ export class HlsMuxer extends Muxer {
 	targetSegmentDuration: number;
 	trackDatas: HlsTrackData[] = [];
 	singleFilePerPlaylist: boolean;
+	singleFilePerPlaylistMode: NonNullable<HlsOutputFormatOptions['singleFilePerPlaylistMode']>;
 	isLive: boolean;
 	maxLiveSegmentCount: number;
 	isRelativeToUnixEpoch = false;
@@ -130,6 +152,7 @@ export class HlsMuxer extends Muxer {
 		this.format = format;
 		this.targetSegmentDuration = format._options.targetDuration ?? 2;
 		this.singleFilePerPlaylist = format._options.singleFilePerPlaylist ?? false;
+		this.singleFilePerPlaylistMode = format._options.singleFilePerPlaylistMode ?? 'segments';
 		this.isLive = format._options.live ?? false;
 		this.maxLiveSegmentCount = format._options.maxLiveSegmentCount ?? Infinity;
 		this.globalTargetDuration = this.targetSegmentDuration;
@@ -465,6 +488,8 @@ export class HlsMuxer extends Muxer {
 				mediaSequence: 0,
 				done: false,
 				singleFile: null,
+				standaloneSingleFile: null,
+				standaloneSegmentInfos: [],
 				mutex: new AsyncMutex(),
 			};
 			this.playlists.push(playlist);
@@ -672,6 +697,93 @@ export class HlsMuxer extends Muxer {
 		throw new Error('Unreachable.');
 	}
 
+	private async ensureStandaloneSingleFileOutput(playlist: Playlist) {
+		if (playlist.standaloneSingleFile) {
+			return playlist.standaloneSingleFile;
+		}
+
+		if (!(playlist.segmentFormat instanceof Mp4OutputFormat)) {
+			throw new Error('singleFilePerPlaylistMode=\'standalone\' currently requires Mp4OutputFormat.');
+		}
+
+		assert(this.output._target instanceof PathedTarget);
+		const pathedTarget = this.output._target;
+
+		const segmentInfo: HlsOutputSegmentInfo = {
+			n: playlist.nextSegmentId,
+			format: playlist.segmentFormat,
+			isSingleFile: true,
+			playlist: toPlaylistInfo(playlist),
+		};
+
+		const relativeSegmentPath = await this.getSegmentPath(segmentInfo);
+		validateSegmentPath(relativeSegmentPath);
+
+		const fullSegmentPath = joinPaths(
+			joinPaths(pathedTarget.rootPath, playlist.path),
+			relativeSegmentPath,
+		);
+
+		const originalOptions = playlist.segmentFormat._options;
+		const fragments: StandaloneSingleFile['fragments'] = [];
+		const standaloneFormat = new Mp4OutputFormat({
+			...originalOptions,
+			fastStart: 'fragmented',
+			minimumFragmentDuration: this.targetSegmentDuration,
+			onMoof: (data, position, timestamp) => {
+				originalOptions.onMoof?.(data, position, timestamp);
+				fragments.push({
+					start: position,
+					end: null,
+					timestamp,
+				});
+			},
+			onMdat: (data, position) => {
+				originalOptions.onMdat?.(data, position);
+				const fragment = fragments.at(-1);
+				if (fragment) {
+					fragment.end = position + data.byteLength;
+				}
+			},
+		});
+
+		const target = await this.output._getTarget({
+			path: fullSegmentPath,
+			isRoot: false,
+			mimeType: standaloneFormat.mimeType,
+		});
+		const output = new Output({
+			format: standaloneFormat,
+			target,
+		});
+
+		const videoSources = new Map<OutputTrack, EncodedVideoPacketSource>();
+		const audioSources = new Map<OutputTrack, EncodedAudioPacketSource>();
+		for (const track of playlist.tracks) {
+			if (track.isVideoTrack()) {
+				const source = new EncodedVideoPacketSource(track.source._codec);
+				videoSources.set(track, source);
+				output.addVideoTrack(source, track.metadata);
+			} else if (track.isAudioTrack()) {
+				const source = new EncodedAudioPacketSource(track.source._codec);
+				audioSources.set(track, source);
+				output.addAudioTrack(source, track.metadata);
+			}
+		}
+
+		await output.start();
+
+		return playlist.standaloneSingleFile = {
+			output,
+			target,
+			path: relativeSegmentPath,
+			info: segmentInfo,
+			videoSources,
+			audioSources,
+			fragments,
+		};
+	}
+
 	async advancePlaylist(playlist: Playlist) {
 		assert(!playlist.done);
 
@@ -823,6 +935,74 @@ export class HlsMuxer extends Muxer {
 			}
 
 			// We can finalize a new segment!
+			if (this.singleFilePerPlaylistMode === 'standalone') {
+				const standalone = await this.ensureStandaloneSingleFileOutput(playlist);
+				let maxEndTimestamp = -Infinity;
+
+				if (videoTrack) {
+					const source = standalone.videoSources.get(videoTrack.track);
+					assert(source);
+					const meta = { decoderConfig: videoTrack.info.decoderConfig };
+
+					for (let i = 0; i < videoEndIndex; i++) {
+						const packet = videoTrack.packets[i]!;
+
+						await source.add(packet, meta);
+						maxEndTimestamp = Math.max(maxEndTimestamp, packet.timestamp + packet.duration);
+					}
+				}
+
+				if (audioTrack) {
+					const source = standalone.audioSources.get(audioTrack.track);
+					assert(source);
+					const meta = { decoderConfig: audioTrack.info.decoderConfig };
+
+					for (let i = 0; i < audioEndIndex; i++) {
+						const packet = audioTrack.packets[i]!;
+
+						await source.add(packet, meta);
+						maxEndTimestamp = Math.max(maxEndTimestamp, packet.timestamp + packet.duration);
+					}
+				}
+
+				if (videoEndIndex > 0) {
+					assert(videoTrack);
+					videoTrack.packets.splice(0, videoEndIndex);
+				}
+				if (audioEndIndex > 0) {
+					assert(audioTrack);
+					audioTrack.packets.splice(0, audioEndIndex);
+				}
+
+				let minNextTimestamp = Infinity;
+				if (videoTrack && videoTrack.packets.length > 0) {
+					minNextTimestamp = videoTrack.packets[0]!.timestamp;
+				}
+				if (audioTrack && audioTrack.packets.length > 0) {
+					minNextTimestamp = Math.min(minNextTimestamp, audioTrack.packets[0]!.timestamp);
+				}
+
+				const nextSegmentStartTimestamp = minNextTimestamp < Infinity
+					? minNextTimestamp
+					: maxEndTimestamp; // Happens for the last segment for example
+				assert(Number.isFinite(nextSegmentStartTimestamp));
+
+				const segmentDuration = nextSegmentStartTimestamp - playlist.currentSegmentStartTimestamp;
+				assert(segmentDuration >= 0);
+
+				playlist.standaloneSegmentInfos.push({
+					timestamp: playlist.currentSegmentStartTimestamp,
+					duration: segmentDuration,
+				});
+
+				this.globalTargetDuration = Math.max(this.globalTargetDuration, segmentDuration);
+
+				playlist.currentSegmentStartTimestamp = nextSegmentStartTimestamp;
+				// After the first segment, the timestamp is now fixed
+				playlist.currentSegmentStartTimestampIsFixed = true;
+
+				continue;
+			}
 
 			let segmentInfo: HlsOutputSegmentInfo | null = null;
 			let relativeSegmentPath: string;
@@ -1100,7 +1280,51 @@ export class HlsMuxer extends Muxer {
 		assert(!playlist.done);
 		playlist.done = true;
 
-		if (playlist.singleFile) {
+		if (this.singleFilePerPlaylistMode === 'standalone' && playlist.standaloneSingleFile) {
+			const standalone = playlist.standaloneSingleFile;
+			for (const source of standalone.videoSources.values()) {
+				source.close();
+			}
+			for (const source of standalone.audioSources.values()) {
+				source.close();
+			}
+
+			await standalone.output.finalize();
+
+			const fragments = standalone.fragments.filter((fragment): fragment is {
+				start: number;
+				end: number;
+				timestamp: number;
+			} => fragment.end !== null);
+			if (fragments.length > 0) {
+				playlist.initSegment = {
+					path: standalone.path,
+					duration: 0,
+					timestamp: 0,
+					byteSize: fragments[0]!.start,
+					byteOffset: 0,
+					info: null,
+				};
+
+				playlist.writtenSegments = fragments.map((fragment, index) => {
+					const segmentInfo = playlist.standaloneSegmentInfos[index];
+					const nextFragment = fragments[index + 1];
+					const duration = segmentInfo?.duration
+						?? (nextFragment ? nextFragment.timestamp - fragment.timestamp : this.targetSegmentDuration);
+
+					return {
+						path: standalone.path,
+						duration: Math.max(0.001, duration),
+						timestamp: segmentInfo?.timestamp ?? fragment.timestamp,
+						byteSize: fragment.end - fragment.start,
+						byteOffset: fragment.start,
+						info: null,
+					};
+				});
+			}
+
+			this.format._options.onSegment?.(standalone.target, standalone.info);
+		} else if (playlist.singleFile) {
 			await playlist.singleFile.target._flush();
 			await playlist.singleFile.target._finalize();
 

--- a/src/output-format.ts
+++ b/src/output-format.ts
@@ -1216,6 +1216,18 @@ export type HlsOutputFormatOptions = {
 	 */
 	singleFilePerPlaylist?: boolean;
 	/**
+	 * Controls how single-file media playlists are written.
+	 *
+	 * - `'segments'` (default): Concatenate the media segments into a single media resource.
+	 * - `'standalone'`: Write the media resource as one standalone fragmented MP4 and use byte ranges into that file.
+	 *   This makes the media resource playable both through the HLS playlist and directly in fragmented-MP4-capable
+	 *   players.
+	 *
+	 * The `'standalone'` mode requires {@link HlsOutputFormatOptions.singleFilePerPlaylist} and
+	 * {@link Mp4OutputFormat}, and is only supported for VOD outputs.
+	 */
+	singleFilePerPlaylistMode?: 'segments' | 'standalone';
+	/**
 	 * If `true`, the muxer will be in "live mode", continuously emitting updated playlists as new segments are created.
 	 * The master playlist will be emitted as soon as all playlists have been emitted at least once, and will continue
 	 * to be emitted each time a segment is finalized to further refine the accuracy of the `BANDWIDTH` attribute.
@@ -1325,6 +1337,20 @@ export class HlsOutputFormat extends OutputFormat {
 		}
 		if (options.singleFilePerPlaylist !== undefined && typeof options.singleFilePerPlaylist !== 'boolean') {
 			throw new TypeError('options.singleFilePerPlaylist, when provided, must be a boolean.');
+		}
+		if (
+			options.singleFilePerPlaylistMode !== undefined
+			&& !['segments', 'standalone'].includes(options.singleFilePerPlaylistMode)
+		) {
+			throw new TypeError(
+				'options.singleFilePerPlaylistMode, when provided, must be either \'segments\' or \'standalone\'.',
+			);
+		}
+		if (options.singleFilePerPlaylistMode === 'standalone' && !options.singleFilePerPlaylist) {
+			throw new TypeError('options.singleFilePerPlaylistMode=\'standalone\' requires singleFilePerPlaylist.');
+		}
+		if (options.singleFilePerPlaylistMode === 'standalone' && options.live) {
+			throw new TypeError('options.singleFilePerPlaylistMode=\'standalone\' is only supported for VOD outputs.');
 		}
 		if (options.live !== undefined && typeof options.live !== 'boolean') {
 			throw new TypeError('options.live, when provided, must be a boolean.');

--- a/test/node/hls-output.test.ts
+++ b/test/node/hls-output.test.ts
@@ -29,6 +29,34 @@ import { EncodedPacketSink } from '../../src/media-sink.js';
 const videoSource = (codec: VideoCodec = 'avc') => new EncodedVideoPacketSource(codec);
 const audioSource = (codec: AudioCodec = 'aac') => new EncodedAudioPacketSource(codec);
 
+const getTopLevelBoxTypes = (buffer: ArrayBuffer) => {
+	const bytes = new Uint8Array(buffer);
+	const view = new DataView(buffer);
+	const boxTypes: string[] = [];
+
+	let offset = 0;
+	while (offset + 8 <= bytes.byteLength) {
+		let size = view.getUint32(offset);
+		let headerSize = 8;
+		const type = String.fromCharCode(...bytes.subarray(offset + 4, offset + 8));
+
+		if (size === 1) {
+			size = Number(view.getBigUint64(offset + 8));
+			headerSize = 16;
+		} else if (size === 0) {
+			size = bytes.byteLength - offset;
+		}
+		if (size < headerSize) {
+			break;
+		}
+
+		boxTypes.push(type);
+		offset += size;
+	}
+
+	return boxTypes;
+};
+
 test('Playlist assignment, single video', async () => {
 	const output = new Output({
 		format: new HlsOutputFormat({
@@ -2246,6 +2274,81 @@ test('CMAF segmentation, single file per playlist', async () => {
 	expect(playlistText!.match(/#EXT-X-BYTERANGE/g)).toHaveLength(2);
 	expect(playlistText).toContain('#EXT-X-VERSION:6');
 	expect(playlistText).toContain('#EXT-X-MAP:URI=');
+});
+
+test('Single-file standalone MP4 mode', async () => {
+	let playlistText: string | null = null;
+	const targets = new Map<string, BufferTarget>();
+
+	const output = new Output({
+		format: new HlsOutputFormat({
+			segmentFormat: new Mp4OutputFormat(),
+			targetDuration: 2,
+			singleFilePerPlaylist: true,
+			singleFilePerPlaylistMode: 'standalone',
+			getSegmentPath: () => 'video.mp4',
+		}),
+		target: new PathedTarget('', (request) => {
+			const target = new BufferTarget();
+			targets.set(request.path, target);
+
+			if (request.path.includes('playlist')) {
+				target.on('finalized', () => {
+					playlistText = new TextDecoder().decode(target.buffer!);
+				});
+			}
+
+			return target;
+		}),
+	});
+
+	const source = videoSource();
+	output.addVideoTrack(source);
+
+	await output.start();
+
+	await source.add(new EncodedPacket(avcPacketData, 'key', 0, 0), avcMetadata);
+	await source.add(new EncodedPacket(avcPacketData, 'delta', 0.5, 0), avcMetadata);
+	await source.add(new EncodedPacket(avcPacketData, 'delta', 1, 0), avcMetadata);
+	await source.add(new EncodedPacket(avcPacketData, 'delta', 1.5, 0), avcMetadata);
+	await source.add(new EncodedPacket(avcPacketData, 'key', 2, 0), avcMetadata);
+	await source.add(new EncodedPacket(avcPacketData, 'delta', 2.5, 0), avcMetadata);
+	await source.add(new EncodedPacket(avcPacketData, 'delta', 3, 0), avcMetadata);
+	await source.add(new EncodedPacket(avcPacketData, 'delta', 3.5, 0), avcMetadata);
+
+	await output.finalize();
+
+	expect(targets.has('video.mp4')).toBe(true);
+	expect(targets.has('init-1.mp4')).toBe(false);
+
+	expect(playlistText).not.toBeNull();
+	expect(playlistText!.match(/#EXT-X-BYTERANGE/g)).toHaveLength(2);
+	expect(playlistText).toContain('#EXT-X-VERSION:6');
+	expect(playlistText).toContain('#EXT-X-MAP:URI="video.mp4",BYTERANGE=');
+
+	const mediaTarget = targets.get('video.mp4')!;
+	const boxTypes = getTopLevelBoxTypes(mediaTarget.buffer!);
+
+	expect(boxTypes.slice(0, 2)).toEqual(['ftyp', 'moov']);
+	expect(boxTypes).toContain('moof');
+	expect(boxTypes).toContain('mdat');
+	expect(boxTypes).toContain('mfra');
+	expect(boxTypes).not.toContain('styp');
+
+	using input = new Input({
+		source: new BufferSource(mediaTarget.buffer!),
+		formats: ALL_FORMATS,
+	});
+	const videoTrack = await input.getPrimaryVideoTrack() as InputVideoTrack;
+	expect(videoTrack).toBeTruthy();
+
+	const sink = new EncodedPacketSink(videoTrack);
+	let packetCount = 0;
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	for await (const packet of sink.packets()) {
+		packetCount++;
+	}
+	expect(packetCount).toBe(8);
 });
 
 test('Live mode', async () => {


### PR DESCRIPTION
## Summary
- Add `singleFilePerPlaylistMode: 'standalone'` for HLS outputs that write one standalone fragmented MP4 media file.
- Preserve the existing single-file behavior as the default `segments` mode.
- Cover the new mode with a node test that verifies byte-range playlist output and standalone MP4 box layout/readability.

## Test plan
- `npx vitest run test/node/hls-output.test.ts`
- `npm run lint`
- `npm run build`
- `npm run test-node`


Made with [Cursor](https://cursor.com)