### PR TITLE
Support QuickTime nclc color information

### DIFF
--- a/src/input-track.ts
+++ b/src/input-track.ts
@@ -691,7 +691,7 @@ export class InputVideoTrack extends InputTrack {
 		const colorSpace = await this._backing.getColorSpace();
 
 		return (colorSpace.primaries as string) === 'bt2020' || (colorSpace.primaries as string) === 'smpte432'
-			|| (colorSpace.transfer as string) === 'pg' || (colorSpace.transfer as string) === 'hlg'
+			|| (colorSpace.transfer as string) === 'pq' || (colorSpace.transfer as string) === 'hlg'
 			|| (colorSpace.matrix as string) === 'bt2020-ncl';
 	}
 

--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -741,11 +741,13 @@ export const pasp = (trackData: IsobmffVideoTrackData) => {
 
 /** Colour Information Box: Specifies the color space of the video. */
 export const colr = (trackData: IsobmffVideoTrackData) => box('colr', [
-	ascii('nclx'), // Colour type
+	ascii(trackData.muxer.isQuickTime ? 'nclc' : 'nclx'), // Colour type
 	u16(COLOR_PRIMARIES_MAP[trackData.info.decoderConfig.colorSpace!.primaries!]), // Colour primaries
 	u16(TRANSFER_CHARACTERISTICS_MAP[trackData.info.decoderConfig.colorSpace!.transfer!]), // Transfer characteristics
 	u16(MATRIX_COEFFICIENTS_MAP[trackData.info.decoderConfig.colorSpace!.matrix!]), // Matrix coefficients
-	u8((trackData.info.decoderConfig.colorSpace!.fullRange ? 1 : 0) << 7), // Full range flag
+	trackData.muxer.isQuickTime
+		? [] // Doesn't have it
+		: u8((trackData.info.decoderConfig.colorSpace!.fullRange ? 1 : 0) << 7), // Full range flag
 ]);
 
 /** AVC Configuration Box: Provides additional information to the decoder. */

--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -1448,20 +1448,19 @@ export class IsobmffDemuxer extends Demuxer {
 				assert(track.info?.type === 'video');
 
 				const colourType = readAscii(slice, 4);
-				if (colourType !== 'nclx') {
+				if (colourType !== 'nclx' && colourType !== 'nclc') {
 					break;
 				}
 
 				const colourPrimaries = readU16Be(slice);
 				const transferCharacteristics = readU16Be(slice);
 				const matrixCoefficients = readU16Be(slice);
-				const fullRangeFlag = Boolean(readU8(slice) & 0x80);
 
 				track.info.colorSpace = {
 					primaries: COLOR_PRIMARIES_MAP_INVERSE[colourPrimaries],
 					transfer: TRANSFER_CHARACTERISTICS_MAP_INVERSE[transferCharacteristics],
 					matrix: MATRIX_COEFFICIENTS_MAP_INVERSE[matrixCoefficients],
-					fullRange: fullRangeFlag,
+					...(colourType === 'nclx' ? { fullRange: Boolean(readU8(slice) & 0x80) } : {}),
 				} as VideoColorSpaceInit;
 			}; break;
 

--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -1456,11 +1456,16 @@ export class IsobmffDemuxer extends Demuxer {
 				const transferCharacteristics = readU16Be(slice);
 				const matrixCoefficients = readU16Be(slice);
 
+				let fullRange: boolean | undefined = undefined;
+				if (colourType === 'nclx') {
+					fullRange = Boolean(readU8(slice) & 0x80);
+				}
+
 				track.info.colorSpace = {
 					primaries: COLOR_PRIMARIES_MAP_INVERSE[colourPrimaries],
 					transfer: TRANSFER_CHARACTERISTICS_MAP_INVERSE[transferCharacteristics],
 					matrix: MATRIX_COEFFICIENTS_MAP_INVERSE[matrixCoefficients],
-					...(colourType === 'nclx' ? { fullRange: Boolean(readU8(slice) & 0x80) } : {}),
+					fullRange,
 				} as VideoColorSpaceInit;
 			}; break;
 

--- a/test/node/read-mp4.test.ts
+++ b/test/node/read-mp4.test.ts
@@ -11,6 +11,7 @@ import {
 	Input,
 	MP4,
 	MovOutputFormat,
+	Mp4OutputFormat,
 	Output,
 } from '../../src/index.js';
 
@@ -46,29 +47,54 @@ test('Should be able to get packets from a .MP4 file', async () => {
 	]);
 });
 
-const replaceColorInformationType = (buffer: ArrayBuffer, from: string, to: string) => {
-	const bytes = new Uint8Array(buffer.slice(0));
-	const needle = new TextEncoder().encode(from);
-	const replacement = new TextEncoder().encode(to);
-	const colorInformationBox = new TextEncoder().encode('colr');
+test('MP4 nclx color information', async () => {
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+	const source = new EncodedVideoPacketSource('vp8');
+	output.addVideoTrack(source);
 
-	expect(replacement.byteLength).toBe(needle.byteLength);
-	expect(replacement.byteLength).toBe(4);
+	await output.start();
+	await source.add(
+		new EncodedPacket(new Uint8Array(1024), 'key', 0, 0.1),
+		{
+			decoderConfig: {
+				codec: 'vp8',
+				codedWidth: 1280,
+				codedHeight: 720,
+				colorSpace: {
+					primaries: 'bt2020' as VideoColorPrimaries,
+					transfer: 'pq' as VideoTransferCharacteristics,
+					matrix: 'bt2020-ncl' as VideoMatrixCoefficients,
+					fullRange: false,
+				},
+			},
+		},
+	);
+	await output.finalize();
 
-	for (let i = 0; i <= bytes.byteLength - colorInformationBox.byteLength - needle.byteLength; i++) {
-		const matches = colorInformationBox.every((value, j) => bytes[i + j] === value);
-		if (matches) {
-			const colorTypeOffset = i + colorInformationBox.byteLength;
-			expect(bytes.slice(colorTypeOffset, colorTypeOffset + needle.byteLength)).toEqual(needle);
-			bytes.set(replacement, colorTypeOffset);
-			return bytes;
-		}
-	}
+	const str = String.fromCharCode(...new Uint8Array(output.target.buffer!));
+	expect(str.includes('nclc')).toBe(false);
+	expect(str.includes('nclx')).toBe(true);
 
-	throw new Error('Could not find color information box');
-};
+	using input = new Input({
+		source: new BufferSource(output.target.buffer!),
+		formats: ALL_FORMATS,
+	});
+	const track = await input.getPrimaryVideoTrack();
+	if (!track) throw new Error('No video track found');
 
-test('Should read QuickTime nclc color information', async () => {
+	expect(await track.getColorSpace()).toEqual({
+		primaries: 'bt2020',
+		transfer: 'pq',
+		matrix: 'bt2020-ncl',
+		fullRange: false,
+	});
+	expect(await track.hasHighDynamicRange()).toBe(true);
+});
+
+test('QuickTime nclc color information', async () => {
 	const output = new Output({
 		format: new MovOutputFormat(),
 		target: new BufferTarget(),
@@ -95,9 +121,12 @@ test('Should read QuickTime nclc color information', async () => {
 	);
 	await output.finalize();
 
-	const nclcFile = replaceColorInformationType(output.target.buffer!, 'nclx', 'nclc');
+	const str = String.fromCharCode(...new Uint8Array(output.target.buffer!));
+	expect(str.includes('nclc')).toBe(true);
+	expect(str.includes('nclx')).toBe(false);
+
 	using input = new Input({
-		source: new BufferSource(nclcFile),
+		source: new BufferSource(output.target.buffer!),
 		formats: ALL_FORMATS,
 	});
 	const track = await input.getPrimaryVideoTrack();

--- a/test/node/read-mp4.test.ts
+++ b/test/node/read-mp4.test.ts
@@ -1,6 +1,18 @@
 import { expect, test } from 'vitest';
 import path from 'node:path';
-import { ALL_FORMATS, MP4, EncodedPacketSink, Input, FilePathSource } from '../../src/index.js';
+import {
+	ALL_FORMATS,
+	BufferSource,
+	BufferTarget,
+	EncodedPacket,
+	EncodedPacketSink,
+	EncodedVideoPacketSource,
+	FilePathSource,
+	Input,
+	MP4,
+	MovOutputFormat,
+	Output,
+} from '../../src/index.js';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
@@ -32,4 +44,66 @@ test('Should be able to get packets from a .MP4 file', async () => {
 	expect(timestamps.slice(0, 10)).toEqual([
 		0, 0.16, 0.08, 0.04, 0.12, 0.32, 0.24, 0.2, 0.28, 0.48,
 	]);
+});
+
+const replaceFirstAscii = (buffer: ArrayBuffer, from: string, to: string) => {
+	const bytes = new Uint8Array(buffer.slice(0));
+	const needle = new TextEncoder().encode(from);
+	const replacement = new TextEncoder().encode(to);
+
+	expect(replacement.byteLength).toBe(needle.byteLength);
+
+	for (let i = 0; i <= bytes.byteLength - needle.byteLength; i++) {
+		const matches = needle.every((value, j) => bytes[i + j] === value);
+		if (matches) {
+			bytes.set(replacement, i);
+			return bytes;
+		}
+	}
+
+	throw new Error(`Could not find ${from}`);
+};
+
+test('Should read QuickTime nclc color information', async () => {
+	const output = new Output({
+		format: new MovOutputFormat(),
+		target: new BufferTarget(),
+	});
+	const source = new EncodedVideoPacketSource('vp8');
+	output.addVideoTrack(source);
+
+	await output.start();
+	await source.add(
+		new EncodedPacket(new Uint8Array(1024), 'key', 0, 0.1),
+		{
+			decoderConfig: {
+				codec: 'vp8',
+				codedWidth: 1280,
+				codedHeight: 720,
+				colorSpace: {
+					primaries: 'bt2020' as VideoColorPrimaries,
+					transfer: 'pq' as VideoTransferCharacteristics,
+					matrix: 'bt2020-ncl' as VideoMatrixCoefficients,
+					fullRange: false,
+				},
+			},
+		},
+	);
+	await output.finalize();
+
+	const nclcFile = replaceFirstAscii(output.target.buffer!, 'nclx', 'nclc');
+	using input = new Input({
+		source: new BufferSource(nclcFile),
+		formats: ALL_FORMATS,
+	});
+	const track = await input.getPrimaryVideoTrack();
+	if (!track) throw new Error('No video track found');
+
+	expect(await track.getColorSpace()).toEqual({
+		primaries: 'bt2020',
+		transfer: 'pq',
+		matrix: 'bt2020-ncl',
+		fullRange: undefined,
+	});
+	expect(await track.hasHighDynamicRange()).toBe(true);
 });

--- a/test/node/read-mp4.test.ts
+++ b/test/node/read-mp4.test.ts
@@ -46,22 +46,26 @@ test('Should be able to get packets from a .MP4 file', async () => {
 	]);
 });
 
-const replaceFirstAscii = (buffer: ArrayBuffer, from: string, to: string) => {
+const replaceColorInformationType = (buffer: ArrayBuffer, from: string, to: string) => {
 	const bytes = new Uint8Array(buffer.slice(0));
 	const needle = new TextEncoder().encode(from);
 	const replacement = new TextEncoder().encode(to);
+	const colorInformationBox = new TextEncoder().encode('colr');
 
 	expect(replacement.byteLength).toBe(needle.byteLength);
+	expect(replacement.byteLength).toBe(4);
 
-	for (let i = 0; i <= bytes.byteLength - needle.byteLength; i++) {
-		const matches = needle.every((value, j) => bytes[i + j] === value);
+	for (let i = 0; i <= bytes.byteLength - colorInformationBox.byteLength - needle.byteLength; i++) {
+		const matches = colorInformationBox.every((value, j) => bytes[i + j] === value);
 		if (matches) {
-			bytes.set(replacement, i);
+			const colorTypeOffset = i + colorInformationBox.byteLength;
+			expect(bytes.slice(colorTypeOffset, colorTypeOffset + needle.byteLength)).toEqual(needle);
+			bytes.set(replacement, colorTypeOffset);
 			return bytes;
 		}
 	}
 
-	throw new Error(`Could not find ${from}`);
+	throw new Error('Could not find color information box');
 };
 
 test('Should read QuickTime nclc color information', async () => {
@@ -91,7 +95,7 @@ test('Should read QuickTime nclc color information', async () => {
 	);
 	await output.finalize();
 
-	const nclcFile = replaceFirstAscii(output.target.buffer!, 'nclx', 'nclc');
+	const nclcFile = replaceColorInformationType(output.target.buffer!, 'nclx', 'nclc');
 	using input = new Input({
 		source: new BufferSource(nclcFile),
 		formats: ALL_FORMATS,


### PR DESCRIPTION
## Summary
- Fixes #398
- Parse ISOBMFF `colr` boxes with QuickTime `nclc` color type in addition to ISO `nclx`
- Preserve the `nclx` full-range flag behavior while leaving `fullRange` unset for `nclc`
- Fix `InputVideoTrack.hasHighDynamicRange()` to recognize PQ transfer as `pq`

## Test fixture note
The new node test creates a MOV in memory with normal `nclx` color metadata, then rewrites the color information box type from `nclx` to `nclc`. The helper targets the `colr` box payload directly, so the test exercises the demuxer path without adding a binary fixture.

## Tests
- `npx vitest --run test/node/read-mp4.test.ts`
- `npm run check`
- `npm run lint`
- `npm run test-node` currently fails locally in unrelated `node/server-extension.test.ts > Video > Memory doesn't leak` RSS assertion (`expected 12926976 to be less than 10485760` on isolated rerun; full suite saw `31309824`).
