### PR TITLE
Fix HLS master playlist codec strings

### DIFF
--- a/src/hls/hls-codecs.ts
+++ b/src/hls/hls-codecs.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) 2026-present, Vanilagy and contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+const HLS_CODEC_ALIASES = new Map([
+	['aac', 'mp4a.40.2'],
+	['mp3', 'mp4a.40.34'],
+	['mp4a.69', 'mp4a.40.34'],
+	['mp4a.6B', 'mp4a.40.34'],
+	['mp4a.6b', 'mp4a.40.34'],
+	['ac3', 'ac-3'],
+	['eac3', 'ec-3'],
+	['flac', 'fLaC'],
+	['webvtt', 'wvtt'],
+]);
+
+const NEEDS_FULL_CODEC_STRING = new Set([
+	'avc',
+	'hevc',
+	'vp9',
+	'av1',
+]);
+
+/** @internal */
+export const toHlsCodecString = (codecString: string) => {
+	const alias = HLS_CODEC_ALIASES.get(codecString);
+	if (alias) {
+		return alias;
+	}
+
+	if (NEEDS_FULL_CODEC_STRING.has(codecString)) {
+		return null;
+	}
+
+	return codecString;
+};

--- a/src/hls/hls-muxer.ts
+++ b/src/hls/hls-muxer.ts
@@ -38,6 +38,7 @@ import { Writer } from '../writer';
 import { EncodedPacket } from '../packet';
 import { SubtitleCue, SubtitleMetadata } from '../subtitles';
 import { NullTarget, PathedTarget, Target, TargetRequest } from '../target';
+import { toHlsCodecString } from './hls-codecs';
 import { HLS_MIME_TYPE } from './hls-misc';
 
 type HlsTrackData = {
@@ -1255,10 +1256,17 @@ export class HlsMuxer extends Muxer {
 					&& decl.playlist.tracks[0].metadata.hasOnlyKeyPackets;
 
 				const codecs: string[] = [];
+				let hasUnknownCodec = false;
 				for (const track of decl.playlist.tracks) {
 					const trackData = this.trackDatas.find(x => x.track === track);
-					const codecString = trackData?.info.decoderConfig.codec ?? track.source._codec;
-					codecs.push(codecString);
+					const codecString = toHlsCodecString(
+						trackData?.info.decoderConfig.codec ?? track.source._codec,
+					);
+					if (codecString) {
+						codecs.push(codecString);
+					} else {
+						hasUnknownCodec = true;
+					}
 				}
 
 				let peakDeclBitrate = 0;
@@ -1268,8 +1276,14 @@ export class HlsMuxer extends Muxer {
 					const firstRef = decl.references[0]!;
 					const firstTrack = firstRef.playlist.tracks[0]!;
 					const trackData = this.trackDatas.find(x => x.track === firstTrack);
-					const codecString = trackData?.info.decoderConfig.codec ?? firstTrack.source._codec;
-					codecs.push(codecString);
+					const codecString = toHlsCodecString(
+						trackData?.info.decoderConfig.codec ?? firstTrack.source._codec,
+					);
+					if (codecString) {
+						codecs.push(codecString);
+					} else {
+						hasUnknownCodec = true;
+					}
 
 					for (const ref of decl.references) {
 						assert(ref.playlist.peakBitrate !== null);
@@ -1299,7 +1313,9 @@ export class HlsMuxer extends Muxer {
 					masterPlaylistText += `,AVERAGE-BANDWIDTH=${Math.ceil(totalAverageBitrate)}`;
 				}
 
-				masterPlaylistText += `,CODECS="${codecs.join(',')}"`;
+				if (!hasUnknownCodec && codecs.length > 0) {
+					masterPlaylistText += `,CODECS="${codecs.join(',')}"`;
+				}
 
 				const videoTrack = decl.playlist.tracks.find(x => x.isVideoTrack());
 				if (videoTrack?.isVideoTrack()) {

--- a/test/node/hls-output.test.ts
+++ b/test/node/hls-output.test.ts
@@ -6,6 +6,7 @@ import {
 	HlsOutputSegmentInfo,
 	Mp4OutputFormat,
 	MpegTsOutputFormat,
+	OutputFormat,
 } from '../../src/output-format.js';
 import {
 	AppendOnlyStreamTarget,
@@ -28,6 +29,65 @@ import { EncodedPacketSink } from '../../src/media-sink.js';
 
 const videoSource = (codec: VideoCodec = 'avc') => new EncodedVideoPacketSource(codec);
 const audioSource = (codec: AudioCodec = 'aac') => new EncodedAudioPacketSource(codec);
+
+const getAudioOnlyMasterPlaylistText = async (
+	codec: AudioCodec,
+	segmentFormat: OutputFormat = new MpegTsOutputFormat(),
+) => {
+	let masterPlaylistText = '';
+	const source = audioSource(codec);
+	const output = new Output({
+		format: new HlsOutputFormat({
+			segmentFormat,
+		}),
+		target: new PathedTarget('master.m3u8', ({ path }) => {
+			const target = new BufferTarget();
+			if (path === 'master.m3u8') {
+				target.on('finalized', () => {
+					masterPlaylistText = new TextDecoder().decode(target.buffer!);
+				});
+			}
+
+			return target;
+		}),
+	});
+
+	output.addAudioTrack(source);
+
+	await output.start();
+	source.close();
+	await output.finalize();
+
+	return masterPlaylistText;
+};
+
+const getVideoOnlyMasterPlaylistText = async (codec: VideoCodec) => {
+	let masterPlaylistText = '';
+	const source = videoSource(codec);
+	const output = new Output({
+		format: new HlsOutputFormat({
+			segmentFormat: new MpegTsOutputFormat(),
+		}),
+		target: new PathedTarget('master.m3u8', ({ path }) => {
+			const target = new BufferTarget();
+			if (path === 'master.m3u8') {
+				target.on('finalized', () => {
+					masterPlaylistText = new TextDecoder().decode(target.buffer!);
+				});
+			}
+
+			return target;
+		}),
+	});
+
+	output.addVideoTrack(source);
+
+	await output.start();
+	source.close();
+	await output.finalize();
+
+	return masterPlaylistText;
+};
 
 test('Playlist assignment, single video', async () => {
 	const output = new Output({
@@ -69,6 +129,28 @@ test('Playlist assignment, single audio', async () => {
 	expect(decl[0]!.playlist.tracks).toHaveLength(1);
 	expect(decl[0]!.groupId).toBeNull();
 	expect(decl[0]!.references).toHaveLength(0);
+});
+
+test('HLS master playlist uses RFC 6381 audio codec strings', async () => {
+	const cases: [AudioCodec, OutputFormat, string][] = [
+		['aac', new MpegTsOutputFormat(), 'mp4a.40.2'],
+		['mp3', new MpegTsOutputFormat(), 'mp4a.40.34'],
+		['ac3', new MpegTsOutputFormat(), 'ac-3'],
+		['eac3', new MpegTsOutputFormat(), 'ec-3'],
+		['flac', new CmafOutputFormat(), 'fLaC'],
+	];
+
+	for (const [codec, segmentFormat, expectedCodecString] of cases) {
+		const masterPlaylistText = await getAudioOnlyMasterPlaylistText(codec, segmentFormat);
+
+		expect(masterPlaylistText).toContain(`CODECS="${expectedCodecString}"`);
+	}
+});
+
+test('HLS master playlist omits CODECS when full video codec string is unavailable', async () => {
+	const masterPlaylistText = await getVideoOnlyMasterPlaylistText('avc');
+
+	expect(masterPlaylistText).not.toContain('CODECS=');
 });
 
 test('Playlist assignment, multiple video', async () => {


### PR DESCRIPTION
## Summary

Fix HLS master playlist `CODECS` values so MediaBunny writes HLS/RFC-style codec identifiers (based on Apple hls specifications) instead of internal codec names.

This maps known HLS aliases such as MP3, AC-3, E-AC-3, and FLAC to the identifiers expected by HLS clients, while preserving already-complete codec strings like `avc1...`, `hvc1...`, `hev1...`, and `mp4a.40.*`.

## Details

- Adds an internal HLS codec-string serializer.
- Maps:
  - `aac` -> `mp4a.40.2`
  - `mp3` -> `mp4a.40.34`
  - `ac3` -> `ac-3`
  - `eac3` -> `ec-3`
  - `flac` -> `fLaC`
  - `webvtt` -> `wvtt`
- Avoids emitting incomplete parameter-dependent video names like `avc`, `hevc`, `vp9`, or `av1` when a full decoder config is unavailable.

## Tests

- `npx vitest --run test/node/hls-output.test.ts`
- `npx eslint src/hls/hls-codecs.ts src/hls/hls-muxer.ts test/node/hls-output.test.ts`
- `npx tsc -p src --noEmit`