### PR TITLE
Fix orphaned queued reads when a freed worker slot is stolen concurrently

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -2108,7 +2108,7 @@ class ReadOrchestrator {
 				}
 			})
 			.finally(() => {
-				if (worker.running) {
+				if (worker.running || this.workers.length >= this.options.maxWorkerCount) {
 					// Rare, but can happen with multiple concurrent reads. In this case, don't do anything.
 					return;
 				}
@@ -2123,24 +2123,15 @@ class ReadOrchestrator {
 					}
 
 					const queuedRead = this.queuedReads[oldestIndex]!;
+					this.queuedReads.splice(oldestIndex, 1);
 
-					// Create the worker before dequeuing the read. Although this worker just stopped running,
-					// this `finally` callback runs on a later microtask - concurrent `read()` calls in that gap
-					// may have already evicted this (now idle, slice-free) worker via LRU and saturated every
-					// slot, making `createWorker` return null. Dequeuing first would then orphan the read: it's
-					// no longer queued, never attached to a worker, and its pending slices' promises never
-					// settle. If no slot is free, leave the read queued - whichever worker stops next drains the
-					// queue from this same block.
 					const newWorker = this.createWorker(
 						queuedRead.hole.start,
 						queuedRead.hole.end,
 						queuedRead.strictTarget,
 					);
-					if (!newWorker) {
-						return;
-					}
+					assert(newWorker); // We just freed up a worker, so this should never fail
 
-					this.queuedReads.splice(oldestIndex, 1);
 					newWorker.pendingSlices = queuedRead.pendingSlices;
 					this.runWorker(newWorker);
 				}

--- a/src/source.ts
+++ b/src/source.ts
@@ -2123,15 +2123,24 @@ class ReadOrchestrator {
 					}
 
 					const queuedRead = this.queuedReads[oldestIndex]!;
-					this.queuedReads.splice(oldestIndex, 1);
 
+					// Create the worker before dequeuing the read. Although this worker just stopped running,
+					// this `finally` callback runs on a later microtask - concurrent `read()` calls in that gap
+					// may have already evicted this (now idle, slice-free) worker via LRU and saturated every
+					// slot, making `createWorker` return null. Dequeuing first would then orphan the read: it's
+					// no longer queued, never attached to a worker, and its pending slices' promises never
+					// settle. If no slot is free, leave the read queued - whichever worker stops next drains the
+					// queue from this same block.
 					const newWorker = this.createWorker(
 						queuedRead.hole.start,
 						queuedRead.hole.end,
 						queuedRead.strictTarget,
 					);
-					assert(newWorker); // We just freed up a worker, so this should never fail
+					if (!newWorker) {
+						return;
+					}
 
+					this.queuedReads.splice(oldestIndex, 1);
 					newWorker.pendingSlices = queuedRead.pendingSlices;
 					this.runWorker(newWorker);
 				}


### PR DESCRIPTION
## The bug

`ReadOrchestrator.runWorker`'s `finally` callback dequeues the oldest queued read and asserts that `createWorker` succeeds:

```ts
this.queuedReads.splice(oldestIndex, 1);
const newWorker = this.createWorker(...);
assert(newWorker); // We just freed up a worker, so this should never fail
```

The assumption races. The `finally` callback runs on a later microtask than the worker's actual stop (`running = false` is cleared synchronously at the end of the worker body, inside the `catch` above, or via `signalWorkerStoppedRunning`). Concurrent `read()` calls in that gap can LRU-evict this now-idle, slice-free worker (`createWorker`'s eviction path) and saturate every slot — at which point `createWorker` returns `null` and the assert throws.

The consequences are worse than the unhandled `Assertion failed.` rejection: the queued read was already spliced out, but never got attached to a worker. Its `pendingSlices`' promises never settle, so the demuxer reads awaiting them hang forever.

**Observed in the wild** (a multi-source composition player, 4 `UrlSource` files read concurrently through one page): 25 back-to-back occurrences of the assert during one composition load, with both worker slots saturated each time. The affected tracks' reads never resolved and their clips were permanently undecodable until reload.

## The fix

Create the worker **first**; only dequeue the read once a slot was actually obtained. If every slot is busy, leave the read queued — this same `finally` block runs on every worker that stops, so the read is picked up by whichever worker stops next. No read can be lost.

## Testing

- `npm run test-node`: 274 passed (the single intermittent failure I saw once also reproduces on unmodified `main`, so it's a pre-existing flake, not this change)
- `tsc -p src` and `eslint` clean
- We've been running this fix in production under heavy multi-source load (as a package patch against 1.45.4) — the assertion storm and the hangs are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)