### PR TITLE
Fix unhandled rejections from deliberate cancellations during dispose

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -528,7 +528,13 @@ export class Input<S extends Source = Source> extends EventEmitter<InputEvents> 
 		this._sourceRefs.length = 0;
 
 		void this._demuxerPromise
-			?.then(demuxer => demuxer.dispose());
+			?.then(demuxer => demuxer.dispose())
+			// This derived chain exists only to dispose the demuxer once it materializes. If dispose() is
+			// called while the demuxer is still initializing (metadata read in flight) and that read then
+			// fails or is aborted, _demuxerPromise rejects - its real awaiters (getPrimaryVideoTrack etc.)
+			// receive the error, but this chain has no consumer and would surface the deliberate cancellation
+			// as an unhandled promise rejection. A demuxer that never came to exist needs no disposal.
+			.catch(() => {});
 	}
 
 	/**

--- a/src/source.ts
+++ b/src/source.ts
@@ -1988,7 +1988,13 @@ class ReadOrchestrator {
 				offset: innerStart,
 			} satisfies ReadResult));
 		} else {
-			// The requested region was satisfied by the cache, but the entire prefetch region was not
+			// The requested region was satisfied by the cache, but the entire prefetch region was not. In this
+			// case, the promise is never handed to the caller - it only tracks completion of the speculative
+			// remainder of the prefetch region. If the worker filling that remainder fails (or its read is
+			// aborted by the caller during teardown), its pending slices reject this promise with no consumer,
+			// surfacing an unhandled promise rejection. Attach a no-op handler: a real failure of this region
+			// is re-encountered - with a consumer - by the next read that actually needs those bytes.
+			promise.catch(() => {});
 		}
 
 		return result;
@@ -2103,7 +2109,12 @@ class ReadOrchestrator {
 				if (worker.pendingSlices.length > 0) {
 					worker.pendingSlices.forEach(x => x.reject(error)); // Make sure to propagate any errors
 					worker.pendingSlices.length = 0;
-				} else {
+				} else if (!worker.aborted && !this.disposed) {
+					// Only rethrow for live workers. An aborted worker (or a disposed orchestrator) rejecting
+					// here is the deliberate cancellation itself - dispose() flags workers aborted before the
+					// caller aborts the underlying reads, so the rejection carries no information, and rethrowing
+					// it into this void'ed chain surfaces an unhandled rejection for every speculative,
+					// slice-free worker cancelled during teardown.
 					throw error; // So it doesn't get swallowed
 				}
 			})


### PR DESCRIPTION
## Context

Same family as #197 (and the spirit of #244): when an `Input` is disposed mid-flight and the app then aborts its in-flight reads, several internal promises reject with nobody to hear them, and a **deliberate cancellation** surfaces in the console as an unhandled promise rejection.

I found three distinct routes by instrumenting `Promise.prototype.then` to attribute the rejecting promise's creation site (a multi-source composition player tearing down `Input`s while reads are in flight). I'm aware #203 was declined because blanket suppression would have masked the real bug there — these three are not suppressions of errors that have a consumer somewhere; in each case the promise is *consumer-less by design* or the rejection *is* the cancellation:

## Route 1 — `ReadOrchestrator.read()`, cache-satisfied branch

When the requested region is covered by cache but the prefetch region is not, `read()` returns the cached result, and the `promise` from `promiseWithResolvers` is never handed to the caller — it only tracks completion of the **speculative prefetch remainder** (the pending slice still references its `reject`). If the worker filling that remainder fails or its read is aborted during teardown, the rejection has no consumer.

Fix: attach a no-op handler in exactly that branch. A real failure of that region is re-encountered — with a consumer — by the next read that actually needs those bytes.

## Route 2 — `ReadOrchestrator.runWorker()`

The `catch` rethrows into a `void`'ed chain when a worker has no pending slices ("so it doesn't get swallowed"). For a **live** worker that's right. But `dispose()` flags workers `aborted` (and the orchestrator `disposed`) *before* the caller aborts the underlying reads — your own comment in `createWorker` documents the workers-after-disposal variant of this ordering. So a rejection arriving on an aborted worker / disposed orchestrator is the deliberate cancellation itself, carrying no information, and every speculative slice-free worker cancelled at teardown becomes an unhandled rejection.

Fix: rethrow only when `!worker.aborted && !this.disposed`. Real errors on live workers still propagate exactly as before.

## Route 3 — `Input.dispose()`

```ts
void this._demuxerPromise?.then(demuxer => demuxer.dispose());
```

This derived chain exists only to dispose the demuxer once it materializes. If `dispose()` is called while the demuxer is still initializing and the metadata read then fails/aborts, `_demuxerPromise` rejects — its real awaiters (`getPrimaryVideoTrack` etc.) receive the error properly, but this chain has no rejection handler. A demuxer that never came to exist needs no disposal.

Fix: `.catch(() => {})` on the derived chain only.

## Testing

- `npm run test-node`: 274 passed; `tsc -p src` and `eslint` clean
- Running in production as a package patch against 1.45.4: all three unhandled-rejection signatures are gone, error propagation to real awaiters unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)