### PR TITLE
Add per-sink decoder preferences (hardwareAcceleration, optimizeForLatency)

### DIFF
--- a/docs/guide/media-sinks.md
+++ b/docs/guide/media-sinks.md
@@ -225,6 +225,11 @@ Create the sink like so:
 import { VideoSampleSink } from 'mediabunny';
 
 const sink = new VideoSampleSink(videoTrack);
+
+// Optionally, configure the decoder:
+const sink = new VideoSampleSink(videoTrack, {
+	hardwarePreference: 'prefer-software',
+});
 ```
 
 #### Single retrieval
@@ -363,6 +368,8 @@ type CanvasSinkOptions = {
 	rotation?: 0 | 90 | 180 | 270;
 	crop?: { left: number; top: number; width: number; height: number };
 	poolSize?: number;
+	alpha?: boolean;
+	decoderOptions?: VideoSinkDecoderOptions;
 };
 ```
 - `width`\
@@ -380,6 +387,10 @@ type CanvasSinkOptions = {
 	Specifies the rectangular region of the input video to crop to. The crop region will automatically be clamped to the dimensions of the input video track. Cropping is performed after rotation but before resizing. The crop region is in the _display pixel space_ of the underlying video data.
 - `poolSize`\
 	See [Canvas pool](#canvas-pool).
+- `alpha`\
+	Whether the output canvases should have transparency instead of a black background. Defaults to `false`. Set this to `true` when using this sink to read transparent videos.
+- `decoderOptions`\
+	Additional preferences for the underlying video decoder.
 
 Some examples:
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,7 @@ export {
 	EncodedPacketSink,
 	type PacketRetrievalOptions,
 	VideoSampleSink,
+	type VideoSinkDecoderOptions,
 	type WrappedAudioBuffer,
 	type WrappedCanvas,
 } from './media-sink';

--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -1750,6 +1750,44 @@ const colorAlphaMergerWorkerCode = () => {
 };
 
 /**
+ * Decoder preferences for sinks that decode video.
+ * @group Media sinks
+ * @public
+ */
+export type VideoSinkDecoderOptions = {
+	/**
+	 * The hardware acceleration preference passed to the underlying `VideoDecoder`. Useful for applications that
+	 * manage many concurrent decoders: the number of concurrent hardware decode sessions is limited (and exceeding
+	 * the limit can fail silently on some platforms), so an application may want to deliberately place some sinks
+	 * on software decoders.
+	 */
+	hardwareAcceleration?: 'no-preference' | 'prefer-hardware' | 'prefer-software';
+	/**
+	 * When `true`, passes the `optimizeForLatency` hint to the underlying `VideoDecoder`, requesting that decoded
+	 * frames be emitted as soon as possible (potentially at the cost of decode throughput).
+	 */
+	optimizeForLatency?: boolean;
+};
+
+const validateVideoSinkDecoderOptions = (decoderOptions: VideoSinkDecoderOptions) => {
+	if (!decoderOptions || typeof decoderOptions !== 'object') {
+		throw new TypeError('decoderOptions must be an object.');
+	}
+	if (
+		decoderOptions.hardwareAcceleration !== undefined
+		&& !['no-preference', 'prefer-hardware', 'prefer-software'].includes(decoderOptions.hardwareAcceleration)
+	) {
+		throw new TypeError(
+			'decoderOptions.hardwareAcceleration, when provided, must be \'no-preference\', \'prefer-hardware\' or'
+			+ ' \'prefer-software\'.',
+		);
+	}
+	if (decoderOptions.optimizeForLatency !== undefined && typeof decoderOptions.optimizeForLatency !== 'boolean') {
+		throw new TypeError('decoderOptions.optimizeForLatency, when provided, must be a boolean.');
+	}
+};
+
+/**
  * A sink that retrieves decoded video samples (video frames) from a video track.
  * @group Media sinks
  * @public
@@ -1757,16 +1795,20 @@ const colorAlphaMergerWorkerCode = () => {
 export class VideoSampleSink extends BaseMediaSampleSink<VideoSample> {
 	/** @internal */
 	_track: InputVideoTrack;
+	/** @internal */
+	_decoderOptions: VideoSinkDecoderOptions;
 
 	/** Creates a new {@link VideoSampleSink} for the given {@link InputVideoTrack}. */
-	constructor(videoTrack: InputVideoTrack) {
+	constructor(videoTrack: InputVideoTrack, decoderOptions: VideoSinkDecoderOptions = {}) {
 		if (!(videoTrack instanceof InputVideoTrack)) {
 			throw new TypeError('videoTrack must be an InputVideoTrack.');
 		}
+		validateVideoSinkDecoderOptions(decoderOptions);
 
 		super();
 
 		this._track = videoTrack;
+		this._decoderOptions = decoderOptions;
 	}
 
 	/** @internal */
@@ -1783,9 +1825,18 @@ export class VideoSampleSink extends BaseMediaSampleSink<VideoSample> {
 
 		const codec = await this._track.getCodec();
 		const rotation = await this._track.getRotation();
-		const decoderConfig = await this._track.getDecoderConfig();
+		let decoderConfig = await this._track.getDecoderConfig();
 		const timeResolution = await this._track.getTimeResolution();
 		assert(codec && decoderConfig);
+
+		// Apply per-sink decoder preferences. This runs before VideoDecoderWrapper's own interlaced-AVC
+		// prefer-software injection, which can only strengthen the preference toward software (no conflict).
+		if (this._decoderOptions.hardwareAcceleration !== undefined) {
+			decoderConfig = { ...decoderConfig, hardwareAcceleration: this._decoderOptions.hardwareAcceleration };
+		}
+		if (this._decoderOptions.optimizeForLatency !== undefined) {
+			decoderConfig = { ...decoderConfig, optimizeForLatency: this._decoderOptions.optimizeForLatency };
+		}
 
 		return new VideoDecoderWrapper(onSample, onError, codec, decoderConfig, rotation, timeResolution);
 	}
@@ -1903,6 +1954,11 @@ export type CanvasSinkOptions = {
 	 * canvas is created each time.
 	 */
 	poolSize?: number;
+	/**
+	 * Decoder preferences forwarded to the underlying {@link VideoSampleSink}'s `VideoDecoder`. See
+	 * {@link VideoSinkDecoderOptions}.
+	 */
+	decoderOptions?: VideoSinkDecoderOptions;
 };
 
 /**
@@ -1982,12 +2038,15 @@ export class CanvasSink {
 		) {
 			throw new TypeError('poolSize must be a non-negative integer.');
 		}
+		if (options.decoderOptions !== undefined) {
+			validateVideoSinkDecoderOptions(options.decoderOptions);
+		}
 
 		this._videoTrack = videoTrack;
 		this._alpha = options.alpha ?? false;
 		this._options = options;
 		this._fit = options.fit ?? 'fill';
-		this._videoSampleSink = new VideoSampleSink(videoTrack);
+		this._videoSampleSink = new VideoSampleSink(videoTrack, options.decoderOptions);
 		this._canvasPool = Array.from({ length: options.poolSize ?? 0 }, () => null);
 	}
 

--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -1750,21 +1750,19 @@ const colorAlphaMergerWorkerCode = () => {
 };
 
 /**
- * Decoder preferences for sinks that decode video.
+ * Describes additional decoder preferences for video sinks.
  * @group Media sinks
  * @public
  */
 export type VideoSinkDecoderOptions = {
 	/**
-	 * The hardware acceleration preference passed to the underlying `VideoDecoder`. Useful for applications that
-	 * manage many concurrent decoders: the number of concurrent hardware decode sessions is limited (and exceeding
-	 * the limit can fail silently on some platforms), so an application may want to deliberately place some sinks
-	 * on software decoders.
+	 * A hint that configures the hardware acceleration method of the decoder. This is best left on `'no-preference'`,
+	 * the default.
 	 */
 	hardwareAcceleration?: 'no-preference' | 'prefer-hardware' | 'prefer-software';
 	/**
-	 * When `true`, passes the `optimizeForLatency` hint to the underlying `VideoDecoder`, requesting that decoded
-	 * frames be emitted as soon as possible (potentially at the cost of decode throughput).
+	 * Hint that the selected decoder should be configured to minimize the number of packets that have to be decoded
+	 * before video frames are output.
 	 */
 	optimizeForLatency?: boolean;
 };
@@ -1829,14 +1827,11 @@ export class VideoSampleSink extends BaseMediaSampleSink<VideoSample> {
 		const timeResolution = await this._track.getTimeResolution();
 		assert(codec && decoderConfig);
 
-		// Apply per-sink decoder preferences. This runs before VideoDecoderWrapper's own interlaced-AVC
-		// prefer-software injection, which can only strengthen the preference toward software (no conflict).
-		if (this._decoderOptions.hardwareAcceleration !== undefined) {
-			decoderConfig = { ...decoderConfig, hardwareAcceleration: this._decoderOptions.hardwareAcceleration };
-		}
-		if (this._decoderOptions.optimizeForLatency !== undefined) {
-			decoderConfig = { ...decoderConfig, optimizeForLatency: this._decoderOptions.optimizeForLatency };
-		}
+		decoderConfig = {
+			...decoderConfig,
+			hardwareAcceleration: this._decoderOptions.hardwareAcceleration,
+			optimizeForLatency: this._decoderOptions.optimizeForLatency,
+		};
 
 		return new VideoDecoderWrapper(onSample, onError, codec, decoderConfig, rotation, timeResolution);
 	}
@@ -1954,10 +1949,7 @@ export type CanvasSinkOptions = {
 	 * canvas is created each time.
 	 */
 	poolSize?: number;
-	/**
-	 * Decoder preferences forwarded to the underlying {@link VideoSampleSink}'s `VideoDecoder`. See
-	 * {@link VideoSinkDecoderOptions}.
-	 */
+	/** Additional preferences for the underlying video decoder. */
 	decoderOptions?: VideoSinkDecoderOptions;
 };
 


### PR DESCRIPTION
## What

Adds an optional `VideoSinkDecoderOptions` (`{ hardwareAcceleration?, optimizeForLatency? }`) second parameter to `VideoSampleSink`, exposed on `CanvasSink` as `options.decoderOptions`, applied to the decoder config before `VideoDecoderWrapper` is constructed. Validation mirrors `decode.ts`'s `validateVideoDecodingConfig`; the type is exported from the package root.

## Why

Applications that run **many sinks concurrently** (multi-track video editors / composition players) need to manage hardware decode sessions deliberately: the number of concurrent hardware sessions is OS-limited, undocumented, varies by hardware/codec/load, and exceeding it **fails silently** on some platforms — on macOS VideoToolbox the excess decoder accepts `configure()` and `decode()` and simply never outputs a frame. The standard mitigation is a decoder pool that places overflow sinks on `'prefer-software'` explicitly, which currently isn't expressible through `CanvasSink`/`VideoSampleSink`.

`optimizeForLatency` is exposed alongside it as the other WebCodecs decoder-config preference an application reasonably wants per sink (e.g. faster first-frame on seek-heavy UIs).

There's precedent for per-config injection in the codebase already: the interlaced-AVC Chromium workaround in `VideoDecoderWrapper` swaps to `'prefer-software'`. The new override composes cleanly with it — the workaround runs later and can only strengthen the preference toward software.

## Testing

- `npm run test-node`: 274 passed; `tsc -p src` and `eslint` clean
- Running in production (as a package patch against 1.45.4) in a composition player that pools ~6 hardware sinks and overflows the rest to `prefer-software` — the silent-stall failure mode is gone

Happy to adjust the API shape (naming, flat options vs. nested `decoderOptions`, validation placement) to your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)