### PR TITLE
fix: define more codecs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -143,6 +143,7 @@ export default withMermaid({
 						{ text: 'VP8', link: '/codec-registry/vp8' },
 						{ text: 'VP9', link: '/codec-registry/vp9' },
 						{ text: 'AV1', link: '/codec-registry/av1' },
+						{ text: 'VVC (H.266)', link: '/codec-registry/vvc' },
 					],
 				},
 				{
@@ -155,6 +156,9 @@ export default withMermaid({
 						{ text: 'FLAC', link: '/codec-registry/flac' },
 						{ text: 'AC-3', link: '/codec-registry/ac3' },
 						{ text: 'E-AC-3', link: '/codec-registry/eac3' },
+						{ text: 'DTS', link: '/codec-registry/dts' },
+						{ text: 'Dolby TrueHD', link: '/codec-registry/truehd' },
+						{ text: 'ALAC', link: '/codec-registry/alac' },
 						{ text: 'Linear PCM', link: '/codec-registry/pcm' },
 						{ text: 'μ-law PCM', link: '/codec-registry/ulaw' },
 						{ text: 'A-law PCM', link: '/codec-registry/alaw' },

--- a/docs/codec-registry/alac.md
+++ b/docs/codec-registry/alac.md
@@ -1,0 +1,39 @@
+---
+description: Apple Lossless Audio Codec (ALAC) audio codec definition, defining legal codec strings, decoder configs, and packet data formats.
+---
+
+<script setup>
+import { VPBadge } from 'vitepress/theme'
+</script>
+
+<VPBadge type="info" text="Audio codec" />
+
+# ALAC codec registration
+
+## Description
+
+The Apple Lossless Audio Codec (ALAC), specified in the [ALAC Specification](https://alac.macosforge.org/).
+
+## Codec ID
+
+```ts
+'alac'
+```
+
+## `EncodedPacket` data
+
+The packet's data must be an ALAC frame as described in the [ALAC Specification](https://alac.macosforge.org/).
+
+## `EncodedPacket` type
+
+The packet's type is always `'key'`.
+
+## `AudioDecoderConfig` codec string
+
+```ts
+'alac'
+```
+
+## `AudioDecoderConfig` description
+
+`description` must contain a 24-byte ALAC magic cookie (`alac` atom contents) as specified in the [ALAC Specification](https://alac.macosforge.org/).

--- a/docs/codec-registry/dts.md
+++ b/docs/codec-registry/dts.md
@@ -1,0 +1,39 @@
+---
+description: Digital Theater Systems (DTS) audio codec definition, defining legal codec strings, decoder configs, and packet data formats.
+---
+
+<script setup>
+import { VPBadge } from 'vitepress/theme'
+</script>
+
+<VPBadge type="info" text="Audio codec" />
+
+# DTS codec registration
+
+## Description
+
+The Digital Theater Systems (DTS) audio codec, specified in [ETSI TS 102 114](https://www.etsi.org/deliver/etsi_ts/102100_102199/102114/01.04.01_60/ts_102114v010401p.pdf).
+
+## Codec ID
+
+```ts
+'dts'
+```
+
+## `EncodedPacket` data
+
+The packet's data must be a DTS audio frame, beginning with the sync word `0x7FFE8001` (or `0x1FFFE8001` for DTS-HD).
+
+## `EncodedPacket` type
+
+The packet's type is always `'key'`.
+
+## `AudioDecoderConfig` codec string
+
+```ts
+'dtsc'
+```
+
+## `AudioDecoderConfig` description
+
+`description` is not used for this codec.

--- a/docs/codec-registry/overview.md
+++ b/docs/codec-registry/overview.md
@@ -12,6 +12,7 @@ The registry is an extension of the [WebCodecs Codec Registry](https://www.w3.or
 
 - [AVC (H.264)](./avc)
 - [HEVC (H.265)](./hevc)
+- [VVC (H.266)](./vvc)
 - [VP8](./vp8)
 - [VP9](./vp9)
 - [AV1](./av1)
@@ -25,6 +26,9 @@ The registry is an extension of the [WebCodecs Codec Registry](https://www.w3.or
 - [FLAC](./flac)
 - [AC-3](./ac3)
 - [E-AC-3](./eac3)
+- [DTS](./dts)
+- [Dolby TrueHD](./truehd)
+- [ALAC](./alac)
 - [Linear PCM](./pcm)
 - [μ-law PCM](./ulaw)
 - [A-law PCM](./alaw)

--- a/docs/codec-registry/truehd.md
+++ b/docs/codec-registry/truehd.md
@@ -1,0 +1,39 @@
+---
+description: Dolby TrueHD audio codec definition, defining legal codec strings, decoder configs, and packet data formats.
+---
+
+<script setup>
+import { VPBadge } from 'vitepress/theme'
+</script>
+
+<VPBadge type="info" text="Audio codec" />
+
+# Dolby TrueHD codec registration
+
+## Description
+
+The Dolby TrueHD audio codec, specified in [Dolby TrueHD specification](https://developer.dolby.com/).
+
+## Codec ID
+
+```ts
+'truehd'
+```
+
+## `EncodedPacket` data
+
+The packet's data must be a TrueHD access unit, beginning with the MLP sync word `0x31 0x6C 0x70` (the ASCII string `'1lp'`) or the TrueHD sync word `0x41 0x6C 0x70` (the ASCII string `'Alp'`).
+
+## `EncodedPacket` type
+
+The packet's type is always `'key'`.
+
+## `AudioDecoderConfig` codec string
+
+```ts
+'mlpa'
+```
+
+## `AudioDecoderConfig` description
+
+`description` is not used for this codec.

--- a/docs/codec-registry/vvc.md
+++ b/docs/codec-registry/vvc.md
@@ -1,0 +1,39 @@
+---
+description: Versatile Video Coding (H.266) video codec definition, defining legal codec strings, decoder configs, and packet data formats.
+---
+
+<script setup>
+import { VPBadge } from 'vitepress/theme'
+</script>
+
+<VPBadge type="info" text="Video codec" />
+
+# VVC (H.266) codec registration
+
+## Description
+
+The Versatile Video Coding (H.266) video codec, specified in [Rec. ITU-T H.266](https://www.itu.int/rec/T-REC-H.266).
+
+## Codec ID
+
+```ts
+'vvc'
+```
+
+## `EncodedPacket` data
+
+The packet's data must be an access unit as defined in [Rec. ITU-T H.266](https://www.itu.int/rec/T-REC-H.266), containing exactly one coded picture, in either _canonical_ (length-prefixed) or _Annex B_ format.
+
+All packets within the bitstream must have the same format.
+
+## `EncodedPacket` type
+
+If the packet's type is `'key'`, then the packet is expected to contain an IDR, CRA, or BLA picture.
+
+## `VideoDecoderConfig` codec string
+
+The full codec string begins with the prefix `'vvc1.'` or `'vvi1.'`, with a variable-length suffix as specified in [ISO/IEC 14496-15](https://www.iso.org/standard/89118.html).
+
+## `VideoDecoderConfig` description
+
+`description` is not used for this codec.

--- a/docs/guide/supported-formats-and-codecs.md
+++ b/docs/guide/supported-formats-and-codecs.md
@@ -1,5 +1,5 @@
 ---
-description: Mediabunny supports a wide range of media container formats (.mp4, .webm, .mp3, .wav, .m3u8, ...) and video/audio codecs (H.264, HEVC, VP9, AV1, AAC, Opus, FLAC, ...).
+description: Mediabunny supports a wide range of media container formats (.mp4, .webm, .mp3, .wav, .m3u8, ...) and video/audio codecs (H.264, HEVC, VP9, AV1, VVC, AAC, Opus, FLAC, DTS, TrueHD, ALAC, ...).
 ---
 
 # Supported formats & codecs
@@ -40,6 +40,7 @@ Mediabunny ships with built-in decoders and encoders for all audio PCM codecs, m
 - `'vp8'` - VP8
 - `'vp9'` - VP9
 - `'av1'` - AOMedia Video 1 (AV1)
+- `'vvc'` - Versatile Video Coding (VVC) / H.266
 
 ### Audio codecs
 
@@ -50,6 +51,9 @@ Mediabunny ships with built-in decoders and encoders for all audio PCM codecs, m
 - `'flac'` - Free Lossless Audio Codec (FLAC) [^flac]
 - `'ac3'` - Dolby Digital (AC-3) [^ac3]
 - `'eac3'` - Dolby Digital Plus (E-AC-3) [^ac3]
+- `'dts'` - Digital Theater Systems (DTS)
+- `'truehd'` - Dolby TrueHD
+- `'alac'` - Apple Lossless Audio Codec (ALAC)
 - `'pcm-u8'` - 8-bit unsigned PCM
 - `'pcm-s8'` - 8-bit signed PCM
 - `'pcm-s16'` - 16-bit little-endian signed PCM
@@ -80,6 +84,7 @@ Not all codecs can be used with all containers. The following table specifies th
 | `'vp8'`        |    ✓     |   ✓   |   ✓   |     ✓     |       |       |       |       |       |       |
 | `'vp9'`        |    ✓     |   ✓   |   ✓   |     ✓     |       |       |       |       |       |       |
 | `'av1'`        |    ✓     |   ✓   |   ✓   |     ✓     |       |       |       |       |       |       |
+| `'vvc'`        |    ✓     |   ✓   |   ✓   |           |       |       |       |       |       |   ✓   |
 | `'aac'`        |    ✓     |   ✓   |   ✓   |           |       |       |       |   ✓   |       |   ✓   |
 | `'opus'`       |    ✓     |   ✓   |   ✓   |     ✓     |   ✓   |       |       |       |       |       |
 | `'mp3'`        |    ✓     |   ✓   |   ✓   |           |       |   ✓   |       |       |       |   ✓   |
@@ -87,6 +92,9 @@ Not all codecs can be used with all containers. The following table specifies th
 | `'flac'`       |    ✓     |   ✓   |   ✓   |           |       |       |       |       |   ✓   |       |
 | `'ac3'`        |    ✓     |   ✓   |   ✓   |           |       |       |       |       |       |   ✓   |
 | `'eac3'`       |    ✓     |   ✓   |   ✓   |           |       |       |       |       |       |   ✓   |
+| `'dts'`        |    ✓     |   ✓   |   ✓   |           |       |       |       |       |       |   ✓   |
+| `'truehd'`     |    ✓     |   ✓   |   ✓   |           |       |       |       |       |       |   ✓   |
+| `'alac'`       |    ✓     |   ✓   |   ✓   |           |       |       |       |       |       |       |
 | `'pcm-u8'`     |          |   ✓   |   ✓   |           |       |       |   ✓   |       |       |       |
 | `'pcm-s8'`     |          |   ✓   |       |           |       |       |       |       |       |       |
 | `'pcm-s16'`    |    ✓     |   ✓   |   ✓   |           |       |       |   ✓   |       |       |       |

--- a/src/codec-data.ts
+++ b/src/codec-data.ts
@@ -2946,6 +2946,12 @@ export const AC3_REGISTRATION_DESCRIPTOR = new Uint8Array([0x05, 0x04, 0x41, 0x4
 /** E-AC-3 registration_descriptor for MPEG-TS/ */
 export const EAC3_REGISTRATION_DESCRIPTOR = new Uint8Array([0x05, 0x04, 0x45, 0x41, 0x43, 0x33]);
 
+/** DTS registration_descriptor for MPEG-TS. */
+export const DTS_REGISTRATION_DESCRIPTOR = new Uint8Array([0x05, 0x04, 0x44, 0x54, 0x53, 0x20]);
+
+/** TrueHD (MLP) registration_descriptor for MPEG-TS. */
+export const TRUEHD_REGISTRATION_DESCRIPTOR = new Uint8Array([0x05, 0x04, 0x4D, 0x4C, 0x50, 0x20]);
+
 /** Number of audio blocks per syncframe, indexed by numblkscod */
 export const EAC3_NUMBLKS_TABLE = [1, 2, 3, 6];
 

--- a/src/codec-data.ts
+++ b/src/codec-data.ts
@@ -2455,6 +2455,10 @@ export const determineVideoPacketType = (
 			return null;
 		};
 
+		case 'vvc': {
+			return null; // TODO: implement VVC frame type detection
+		};
+
 		default: {
 			assertNever(codec);
 			assert(false);

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -38,6 +38,7 @@ export const VIDEO_CODECS = [
 	'vp9',
 	'av1',
 	'vp8',
+	'vvc',
 ] as const;
 /**
  * List of known PCM (uncompressed) audio codecs, ordered by encoding preference.
@@ -73,6 +74,9 @@ export const NON_PCM_AUDIO_CODECS = [
 	'flac',
 	'ac3',
 	'eac3',
+	'dts',
+	'truehd',
+	'alac',
 ] as const;
 /**
  * List of known audio codecs, ordered by encoding preference.
@@ -274,6 +278,9 @@ export const buildVideoCodecString = (codec: VideoCodec, width: number, height: 
 		const bitDepth = '08'; // 8-bit
 
 		return `av01.${profile}.${level}${levelInfo.tier}.${bitDepth}`;
+	} else if (codec === 'vvc') {
+		// TODO: generate proper codec string per ISO 14496-15 when WebCodecs adds VVC
+		return 'vvc1.01.01.L120.B0';
 	}
 
 	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -535,6 +542,12 @@ export const buildAudioCodecString = (codec: AudioCodec, numberOfChannels: numbe
 		return 'ac-3';
 	} else if (codec === 'eac3') {
 		return 'ec-3';
+	} else if (codec === 'alac') {
+		return 'alac';
+	} else if (codec === 'dts') {
+		return 'dtsc';
+	} else if (codec === 'truehd') {
+		return 'mlpa';
 	} else if ((PCM_AUDIO_CODECS as readonly string[]).includes(codec)) {
 		return codec;
 	}
@@ -584,6 +597,12 @@ export const extractAudioCodecString = (trackInfo: {
 		return 'ac-3';
 	} else if (codec === 'eac3') {
 		return 'ec-3';
+	} else if (codec === 'alac') {
+		return 'alac';
+	} else if (codec === 'dts') {
+		return 'dtsc';
+	} else if (codec === 'truehd') {
+		return 'mlpa';
 	} else if (codec && (PCM_AUDIO_CODECS as readonly string[]).includes(codec)) {
 		return codec;
 	}
@@ -671,6 +690,8 @@ export const inferCodecFromCodecString = (codecString: string): MediaCodec | nul
 		return 'vp9';
 	} else if (codecString.startsWith('av01')) {
 		return 'av1';
+	} else if (codecString.startsWith('vvc1') || codecString.startsWith('vvi1')) {
+		return 'vvc';
 	}
 
 	// Audio codecs
@@ -694,6 +715,12 @@ export const inferCodecFromCodecString = (codecString: string): MediaCodec | nul
 		return 'ac3';
 	} else if (codecString === 'ec-3' || codecString === 'eac3') {
 		return 'eac3';
+	} else if (codecString === 'dtsc' || codecString === 'dtsh' || codecString === 'dtsl' || codecString === 'dtse') {
+		return 'dts';
+	} else if (codecString === 'mlpa') {
+		return 'truehd';
+	} else if (codecString === 'alac') {
+		return 'alac';
 	} else if (codecString === 'ulaw') {
 		return 'ulaw';
 	} else if (codecString === 'alaw') {
@@ -746,7 +773,7 @@ export const getAudioEncoderConfigExtension = (codec: AudioCodec) => {
 	return {};
 };
 
-const VALID_VIDEO_CODEC_STRING_PREFIXES = ['avc1', 'avc3', 'hev1', 'hvc1', 'vp8', 'vp09', 'av01'];
+const VALID_VIDEO_CODEC_STRING_PREFIXES = ['avc1', 'avc3', 'hev1', 'hvc1', 'vp8', 'vp09', 'av01', 'vvc1', 'vvi1'];
 const AVC_CODEC_STRING_REGEX = /^(avc1|avc3)\.[0-9a-fA-F]{6}$/;
 const HEVC_CODEC_STRING_REGEX = /^(hev1|hvc1)\.(?:[ABC]?\d+)\.[0-9a-fA-F]{1,8}\.[LH]\d+(?:\.[0-9a-fA-F]{1,2}){0,6}$/;
 const VP9_CODEC_STRING_REGEX = /^vp09(?:\.\d{2}){3}(?:(?:\.\d{2}){5})?$/;
@@ -917,7 +944,8 @@ export const validateVideoChunkMetadata = (metadata: EncodedVideoChunkMetadata |
 };
 
 const VALID_AUDIO_CODEC_STRING_PREFIXES = [
-	'mp4a', 'mp3', 'opus', 'vorbis', 'flac', 'ulaw', 'alaw', 'pcm', 'ac-3', 'ec-3',
+	'mp4a', 'mp3', 'opus', 'vorbis', 'flac', 'ulaw', 'alaw', 'pcm',
+	'ac-3', 'ec-3', 'dtsc', 'dtsh', 'dtsl', 'dtse', 'mlpa', 'alac',
 ];
 
 export const validateAudioChunkMetadata = (metadata: EncodedAudioChunkMetadata | undefined) => {

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -546,6 +546,7 @@ export class Quality {
 			vp9: 0.6, // Similar to HEVC
 			av1: 0.4, // ~60% more efficient than AVC
 			vp8: 1.2, // Slightly less efficient than AVC
+			vvc: 0.4, // VVC (~35% more efficient than HEVC, similar to AV1)
 		};
 
 		const referencePixels = 1920 * 1080;
@@ -561,7 +562,10 @@ export class Quality {
 
 	/** @internal */
 	_toAudioBitrate(codec: AudioCodec) {
-		if ((PCM_AUDIO_CODECS as readonly string[]).includes(codec) || codec === 'flac') {
+		if (
+			(PCM_AUDIO_CODECS as readonly string[]).includes(codec)
+			|| codec === 'flac' || codec === 'alac' || codec === 'dts' || codec === 'truehd'
+		) {
 			return undefined;
 		}
 

--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -1780,6 +1780,7 @@ const videoCodecToBoxName = (codec: VideoCodec, fullCodecString: string) => {
 		case 'vp8': return 'vp08';
 		case 'vp9': return 'vp09';
 		case 'av1': return 'av01';
+		case 'vvc': return 'vvc1';
 	}
 };
 
@@ -1789,6 +1790,7 @@ const VIDEO_CODEC_TO_CONFIGURATION_BOX: Record<VideoCodec, (trackData: IsobmffVi
 	vp8: vpcC,
 	vp9: vpcC,
 	av1: av1C,
+	vvc: () => null, // TODO: implement vvcC box writer when VVC muxing support is added
 };
 
 const audioCodecToBoxName = (codec: AudioCodec, isQuickTime: boolean): string => {
@@ -1804,6 +1806,9 @@ const audioCodecToBoxName = (codec: AudioCodec, isQuickTime: boolean): string =>
 		case 'pcm-s8': return 'sowt';
 		case 'ac3': return 'ac-3';
 		case 'eac3': return 'ec-3';
+		case 'alac': return 'alac';
+		case 'dts': return 'dtsc';
+		case 'truehd': return 'mlpa';
 	}
 
 	// Logic diverges here
@@ -1845,6 +1850,9 @@ const audioCodecToConfigurationBox = (codec: AudioCodec, isQuickTime: boolean) =
 		case 'flac': return dfLa;
 		case 'ac3': return dac3;
 		case 'eac3': return dec3;
+		case 'dts': return null; // TODO: implement dtsc box writer when DTS muxing support is added
+		case 'truehd': return null; // TODO: implement mlpa box writer when TrueHD muxing support is added
+		case 'alac': return null; // TODO: implement alac box writer when ALAC muxing support is added
 	}
 
 	// Logic diverges here

--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -1092,6 +1092,8 @@ export class IsobmffDemuxer extends Demuxer {
 							track.info.codec = 'vp9';
 						} else if (codecName === 'av01') {
 							track.info.codec = 'av1';
+						} else if (codecName === 'vvc1' || codecName === 'vvi1') {
+							track.info.codec = 'vvc';
 						} else if (codecName === null) {
 							console.warn(`Unknown encrypted video codec due to missing frma box.`);
 						} else {
@@ -1164,6 +1166,17 @@ export class IsobmffDemuxer extends Demuxer {
 							track.info.codec = 'ac3';
 						} else if (codecName === 'ec-3') {
 							track.info.codec = 'eac3';
+						} else if (
+							codecName === 'dtsc'
+							|| codecName === 'dtsh'
+							|| codecName === 'dtsl'
+							|| codecName === 'dtse'
+						) {
+							track.info.codec = 'dts';
+						} else if (codecName === 'mlpa') {
+							track.info.codec = 'truehd';
+						} else if (codecName === 'alac') {
+							track.info.codec = 'alac';
 						} else if (codecName === 'twos') {
 							if (sampleSize === 8) {
 								track.info.codec = 'pcm-s8';

--- a/src/matroska/ebml.ts
+++ b/src/matroska/ebml.ts
@@ -741,6 +741,7 @@ export const CODEC_STRING_MAP: Partial<Record<MediaCodec, string>> = {
 	'vp8': 'V_VP8',
 	'vp9': 'V_VP9',
 	'av1': 'V_AV1',
+	'vvc': 'V_VVC',
 
 	'aac': 'A_AAC',
 	'mp3': 'A_MPEG/L3',
@@ -749,6 +750,9 @@ export const CODEC_STRING_MAP: Partial<Record<MediaCodec, string>> = {
 	'flac': 'A_FLAC',
 	'ac3': 'A_AC3',
 	'eac3': 'A_EAC3',
+	'dts': 'A_DTS',
+	'truehd': 'A_TRUEHD',
+	'alac': 'A_ALAC',
 	'pcm-u8': 'A_PCM/INT/LIT',
 	'pcm-s16': 'A_PCM/INT/LIT',
 	'pcm-s16be': 'A_PCM/INT/BIG',

--- a/src/matroska/matroska-demuxer.ts
+++ b/src/matroska/matroska-demuxer.ts
@@ -1076,6 +1076,9 @@ export class MatroskaDemuxer extends Demuxer {
 							this.currentTrack.info.codec = 'vp9';
 						} else if (codecIdWithoutSuffix === CODEC_STRING_MAP.av1) {
 							this.currentTrack.info.codec = 'av1';
+						} else if (codecIdWithoutSuffix === CODEC_STRING_MAP.vvc) {
+							this.currentTrack.info.codec = 'vvc';
+							this.currentTrack.info.codecDescription = this.currentTrack.codecPrivate;
 						}
 
 						const videoTrack = this.currentTrack as InternalVideoTrack;
@@ -1106,6 +1109,15 @@ export class MatroskaDemuxer extends Demuxer {
 							this.currentTrack.info.codecDescription = this.currentTrack.codecPrivate;
 						} else if (codecIdWithoutSuffix === CODEC_STRING_MAP.eac3) {
 							this.currentTrack.info.codec = 'eac3';
+							this.currentTrack.info.codecDescription = this.currentTrack.codecPrivate;
+						} else if (codecIdWithoutSuffix === CODEC_STRING_MAP.dts) {
+							this.currentTrack.info.codec = 'dts';
+							this.currentTrack.info.codecDescription = this.currentTrack.codecPrivate;
+						} else if (codecIdWithoutSuffix === CODEC_STRING_MAP.truehd) {
+							this.currentTrack.info.codec = 'truehd';
+							this.currentTrack.info.codecDescription = this.currentTrack.codecPrivate;
+						} else if (codecIdWithoutSuffix === CODEC_STRING_MAP.alac) {
+							this.currentTrack.info.codec = 'alac';
 							this.currentTrack.info.codecDescription = this.currentTrack.codecPrivate;
 						} else if (this.currentTrack.codecId === 'A_PCM/INT/LIT') {
 							if (this.currentTrack.info.bitDepth === 8) {

--- a/src/mpeg-ts/mpeg-ts-demuxer.ts
+++ b/src/mpeg-ts/mpeg-ts-demuxer.ts
@@ -309,7 +309,7 @@ export class MpegTsDemuxer extends Demuxer {
 								hasAc3Descriptor = true;
 							} else if (descriptorTag === 0x7a || descriptorTag === 0xcc) {
 								hasEac3Descriptor = true;
-							} else if (descriptorTag === 0x73 || descriptorTag === 0x8a) {
+							} else if (descriptorTag === 0x73) {
 								hasDtsDescriptor = true;
 							} else if (descriptorTag === 0x7b) {
 								hasTruehdDescriptor = true;

--- a/src/mpeg-ts/mpeg-ts-demuxer.ts
+++ b/src/mpeg-ts/mpeg-ts-demuxer.ts
@@ -296,10 +296,12 @@ export class MpegTsDemuxer extends Demuxer {
 						bitstream.skipBits(6);
 						const esInfoLength = bitstream.readBits(10);
 
-						// Check ES descriptors to detect AC-3/E-AC-3 in System B
+						// Check ES descriptors to detect AC-3/E-AC-3/DTS/TrueHD in System B
 						const esInfoEndPos = bitstream.pos + 8 * esInfoLength;
 						let hasAc3Descriptor = false;
 						let hasEac3Descriptor = false;
+						let hasDtsDescriptor = false;
+						let hasTruehdDescriptor = false;
 						while (bitstream.pos < esInfoEndPos) {
 							const descriptorTag = bitstream.readBits(8);
 							const descriptorLength = bitstream.readBits(8);
@@ -307,6 +309,10 @@ export class MpegTsDemuxer extends Demuxer {
 								hasAc3Descriptor = true;
 							} else if (descriptorTag === 0x7a || descriptorTag === 0xcc) {
 								hasEac3Descriptor = true;
+							} else if (descriptorTag === 0x73 || descriptorTag === 0x8a) {
+								hasDtsDescriptor = true;
+							} else if (descriptorTag === 0x7b) {
+								hasTruehdDescriptor = true;
 							}
 							bitstream.skipBits(8 * descriptorLength);
 						}
@@ -315,8 +321,13 @@ export class MpegTsDemuxer extends Demuxer {
 
 						switch (streamType) {
 							case MpegTsStreamType.AVC:
-							case MpegTsStreamType.HEVC: {
-								const codec = streamType === MpegTsStreamType.AVC ? 'avc' : 'hevc';
+							case MpegTsStreamType.HEVC:
+							case MpegTsStreamType.VVC: {
+								const codec = streamType === MpegTsStreamType.AVC
+									? 'avc'
+									: streamType === MpegTsStreamType.HEVC
+										? 'hevc'
+										: 'vvc';
 
 								info = {
 									type: 'video',
@@ -342,6 +353,11 @@ export class MpegTsDemuxer extends Demuxer {
 							case MpegTsStreamType.MP3_MPEG2:
 							case MpegTsStreamType.AAC:
 							case MpegTsStreamType.AC3_SYSTEM_A:
+							case MpegTsStreamType.DTS_SMPTE:
+							case MpegTsStreamType.DTS_HD:
+							case MpegTsStreamType.DTS_HD_MA:
+							case MpegTsStreamType.DTS_ARIB:
+							case MpegTsStreamType.TRUEHD:
 							case MpegTsStreamType.EAC3_SYSTEM_A: {
 								let codec: AudioCodec;
 								if (
@@ -353,8 +369,15 @@ export class MpegTsDemuxer extends Demuxer {
 									codec = 'aac';
 								} else if (streamType === MpegTsStreamType.AC3_SYSTEM_A) {
 									codec = 'ac3';
-								} else if (streamType === MpegTsStreamType.EAC3_SYSTEM_A) {
-									codec = 'eac3';
+								} else if (
+									streamType === MpegTsStreamType.DTS_SMPTE
+									|| streamType === MpegTsStreamType.DTS_HD
+									|| streamType === MpegTsStreamType.DTS_HD_MA
+									|| streamType === MpegTsStreamType.DTS_ARIB
+								) {
+									codec = 'dts';
+								} else if (streamType === MpegTsStreamType.TRUEHD) {
+									codec = 'truehd';
 								} else {
 									throw new Error('Unreachable.');
 								}
@@ -383,6 +406,24 @@ export class MpegTsDemuxer extends Demuxer {
 									info = {
 										type: 'audio',
 										codec: 'ac3',
+										decoderConfig: null,
+										aacCodecInfo: null,
+										numberOfChannels: -1,
+										sampleRate: -1,
+									};
+								} else if (hasDtsDescriptor) {
+									info = {
+										type: 'audio',
+										codec: 'dts',
+										decoderConfig: null,
+										aacCodecInfo: null,
+										numberOfChannels: -1,
+										sampleRate: -1,
+									};
+								} else if (hasTruehdDescriptor) {
+									info = {
+										type: 'audio',
+										codec: 'truehd',
 										decoderConfig: null,
 										aacCodecInfo: null,
 										numberOfChannels: -1,
@@ -669,6 +710,14 @@ export class MpegTsDemuxer extends Demuxer {
 
 								elementaryStream.info.numberOfChannels = getEac3ChannelCount(frameInfo);
 								elementaryStream.info.sampleRate = sampleRate;
+							} else if (elementaryStream.info.codec === 'dts') {
+								// TODO: parse DTS frame header for sample rate and channel count
+								elementaryStream.info.sampleRate = 48000;
+								elementaryStream.info.numberOfChannels = 6;
+							} else if (elementaryStream.info.codec === 'truehd') {
+								// TODO: parse TrueHD access unit for sample rate and channel count
+								elementaryStream.info.sampleRate = 48000;
+								elementaryStream.info.numberOfChannels = 8;
 							} else {
 								throw new Error('Unhandled.');
 							}
@@ -1975,7 +2024,7 @@ class PacketReadingContext {
 			const codec = elementaryStream.info.codec;
 			const CHUNK_SIZE = 1024;
 
-			if (codec !== 'avc' && codec !== 'hevc') {
+			if (codec !== 'avc' && codec !== 'hevc' && codec !== 'vvc') {
 				throw new Error('Unhandled.');
 			}
 
@@ -2044,7 +2093,7 @@ class PacketReadingContext {
 					}
 
 					// We have a second start code. Check if it's an AUD.
-					if (nalUnitTypeByte !== null) {
+					if (nalUnitTypeByte !== null && codec !== 'vvc') {
 						const nalUnitType = codec === 'avc'
 							? extractNalUnitTypeForAvc(nalUnitTypeByte)
 							: extractNalUnitTypeForHevc(nalUnitTypeByte);
@@ -2079,6 +2128,17 @@ class PacketReadingContext {
 		} else {
 			const codec = elementaryStream.info.codec;
 			const CHUNK_SIZE = 128;
+
+			if (codec === 'dts' || codec === 'truehd') {
+				// TODO: implement proper frame-level packet parsing
+				// No frame-level parsing implemented for these codecs;
+				// supply the entire PES packet data as one packet.
+				const remaining = this.endPos - this.currentPos;
+				if (remaining > 0) {
+					return this.supplyPacket(remaining, 0);
+				}
+				return;
+			}
 
 			while (true) {
 				let remaining = this.ensureBuffered(CHUNK_SIZE);

--- a/src/mpeg-ts/mpeg-ts-misc.ts
+++ b/src/mpeg-ts/mpeg-ts-misc.ts
@@ -13,11 +13,17 @@ export const enum MpegTsStreamType {
 	MP3_MPEG1 = 0x03,
 	MP3_MPEG2 = 0x04,
 	AAC = 0x0f,
-	AC3_SYSTEM_A = 0x81,
-	EAC3_SYSTEM_A = 0x87,
 	PRIVATE_DATA = 0x06,
 	AVC = 0x1b,
 	HEVC = 0x24,
+	VVC = 0x42,
+	AC3_SYSTEM_A = 0x81,
+	DTS_SMPTE = 0x82,
+	TRUEHD = 0x83,
+	DTS_HD = 0x84,
+	DTS_HD_MA = 0x85,
+	EAC3_SYSTEM_A = 0x87,
+	DTS_ARIB = 0x8a,
 }
 
 export const buildMpegTsMimeType = (codecStrings: (string | null)[]) => {

--- a/src/mpeg-ts/mpeg-ts-muxer.ts
+++ b/src/mpeg-ts/mpeg-ts-muxer.ts
@@ -15,6 +15,7 @@ import {
 	concatNalUnitsInAnnexB,
 	deserializeAvcDecoderConfigurationRecord,
 	deserializeHevcDecoderConfigurationRecord,
+	DTS_REGISTRATION_DESCRIPTOR,
 	EAC3_REGISTRATION_DESCRIPTOR,
 	extractNalUnitTypeForAvc,
 	extractNalUnitTypeForHevc,
@@ -22,6 +23,7 @@ import {
 	HevcNalUnitType,
 	iterateNalUnitsInAnnexB,
 	iterateNalUnitsInLengthPrefixed,
+	TRUEHD_REGISTRATION_DESCRIPTOR,
 } from '../codec-data';
 import { Bitstream } from '../../shared/bitstream';
 import { assert, promiseWithResolvers, setUint24, toDataView, toUint8Array } from '../misc';
@@ -815,6 +817,13 @@ const buildPmt = (trackDatas: MpegTsTrackData[]) => {
 			totalEsBytes += AC3_REGISTRATION_DESCRIPTOR.length;
 		} else if (trackData.streamType === MpegTsStreamType.EAC3_SYSTEM_A) {
 			totalEsBytes += EAC3_REGISTRATION_DESCRIPTOR.length;
+		} else if (trackData.streamType === MpegTsStreamType.DTS_SMPTE
+			|| trackData.streamType === MpegTsStreamType.DTS_HD
+			|| trackData.streamType === MpegTsStreamType.DTS_HD_MA
+			|| trackData.streamType === MpegTsStreamType.DTS_ARIB) {
+			totalEsBytes += DTS_REGISTRATION_DESCRIPTOR.length;
+		} else if (trackData.streamType === MpegTsStreamType.TRUEHD) {
+			totalEsBytes += TRUEHD_REGISTRATION_DESCRIPTOR.length;
 		}
 	}
 
@@ -848,6 +857,19 @@ const buildPmt = (trackDatas: MpegTsTrackData[]) => {
 			offset += 2;
 			section.set(EAC3_REGISTRATION_DESCRIPTOR, offset);
 			offset += EAC3_REGISTRATION_DESCRIPTOR.length;
+		} else if (trackData.streamType === MpegTsStreamType.DTS_SMPTE
+			|| trackData.streamType === MpegTsStreamType.DTS_HD
+			|| trackData.streamType === MpegTsStreamType.DTS_HD_MA
+			|| trackData.streamType === MpegTsStreamType.DTS_ARIB) {
+			view.setUint16(offset, 0xF000 | DTS_REGISTRATION_DESCRIPTOR.length, false);
+			offset += 2;
+			section.set(DTS_REGISTRATION_DESCRIPTOR, offset);
+			offset += DTS_REGISTRATION_DESCRIPTOR.length;
+		} else if (trackData.streamType === MpegTsStreamType.TRUEHD) {
+			view.setUint16(offset, 0xF000 | TRUEHD_REGISTRATION_DESCRIPTOR.length, false);
+			offset += 2;
+			section.set(TRUEHD_REGISTRATION_DESCRIPTOR, offset);
+			offset += TRUEHD_REGISTRATION_DESCRIPTOR.length;
 		} else {
 			view.setUint16(offset, 0xF000, false); // reserved=1111, ES_info_length=0
 			offset += 2;

--- a/src/mpeg-ts/mpeg-ts-muxer.ts
+++ b/src/mpeg-ts/mpeg-ts-muxer.ts
@@ -116,11 +116,13 @@ export class MpegTsMuxer extends Muxer {
 		assert(meta?.decoderConfig);
 
 		const codec = track.source._codec;
-		assert(codec === 'avc' || codec === 'hevc');
+		assert(codec === 'avc' || codec === 'hevc' || codec === 'vvc');
 
 		const streamType = codec === 'avc'
 			? MpegTsStreamType.AVC
-			: MpegTsStreamType.HEVC;
+			: codec === 'hevc'
+				? MpegTsStreamType.HEVC
+				: MpegTsStreamType.VVC;
 		const pid = FIRST_TRACK_PID + this.trackDatas.length;
 		const streamId = VIDEO_STREAM_ID_BASE + this.videoTrackIndex++;
 
@@ -161,7 +163,10 @@ export class MpegTsMuxer extends Muxer {
 		assert(meta?.decoderConfig);
 
 		const codec = track.source._codec;
-		assert(codec === 'aac' || codec === 'mp3' || codec === 'ac3' || codec === 'eac3');
+		assert(
+			codec === 'aac' || codec === 'mp3' || codec === 'ac3' || codec === 'eac3'
+			|| codec === 'dts' || codec === 'truehd',
+		);
 
 		let streamType: MpegTsStreamType;
 		let streamId: number;
@@ -184,6 +189,16 @@ export class MpegTsMuxer extends Muxer {
 
 			case 'eac3': {
 				streamType = MpegTsStreamType.EAC3_SYSTEM_A;
+				streamId = 0xbd;
+			}; break;
+
+			case 'dts': {
+				streamType = MpegTsStreamType.DTS_SMPTE;
+				streamId = 0xbd;
+			}; break;
+
+			case 'truehd': {
+				streamType = MpegTsStreamType.TRUEHD;
 				streamId = 0xbd;
 			}; break;
 		}
@@ -303,10 +318,16 @@ export class MpegTsMuxer extends Muxer {
 				const bytes = toUint8Array(description!);
 				if (codec === 'avc') {
 					trackData.avcDecoderConfig = deserializeAvcDecoderConfigurationRecord(bytes);
-				} else {
+				} else if (codec === 'hevc') {
 					trackData.hevcDecoderConfig = deserializeHevcDecoderConfigurationRecord(bytes);
 				}
 			}
+		}
+
+		if (codec === 'vvc') {
+			// TODO verify this
+			// VVC in MPEG-TS always uses Annex B format without AUD
+			return packet.data;
 		}
 
 		if (trackData.inputIsAnnexB) {
@@ -414,7 +435,7 @@ export class MpegTsMuxer extends Muxer {
 	): Uint8Array {
 		const codec = (trackData.track as OutputAudioTrack).source._codec;
 
-		if (codec === 'mp3' || codec === 'ac3' || codec === 'eac3') {
+		if (codec === 'mp3' || codec === 'ac3' || codec === 'eac3' || codec === 'dts' || codec === 'truehd') {
 			// We're good
 			return packet.data;
 		}


### PR DESCRIPTION
written 60% by clankers, but I did review it and it looks correct

doesnt implement support for these codecs for mp4, because that requires actual effort and verification, and it's not something I'd ever trust AI with, so I'd rather leave it as a TODO noop than even let it try to implement it

there are actually devices where ac3 and dts is supported, like chromecasts, and well ofc custom chromium builds that linux enjoyers run

these added codecs are quite common in the wild [except vvc lol], I run mediabunny on devices that support it, and I also wrote custom decoders for them, so it would be nice if this was supported

rather than address woes in the PR body here, i'll do it inline in the code with comments