### PR TITLE
fix: preserve AVC key frames before AUD

### DIFF
--- a/src/codec-data.ts
+++ b/src/codec-data.ts
@@ -267,6 +267,29 @@ export const concatAvcNalUnits = (nalUnits: Uint8Array[], decoderConfig: VideoDe
 	}
 };
 
+// This function sanitizes the contents of an AVC packet such that Chromium's key frame detection
+// does not trip up on its contents.
+// See https://issues.chromium.org/issues/470109459.
+export const sanitizeAvcPacketForChromium = (
+	packetData: Uint8Array,
+	decoderConfig: VideoDecoderConfig,
+): Uint8Array => {
+	const filteredNalUnits: Uint8Array[] = [];
+
+	for (const loc of iterateAvcNalUnits(packetData, decoderConfig)) {
+		const type = extractNalUnitTypeForAvc(packetData[loc.offset]!);
+
+		// These trip up Chromium's key frame detection, so let's strip them
+		if (type >= 20 && type <= 31) {
+			continue;
+		}
+
+		filteredNalUnits.push(packetData.subarray(loc.offset, loc.offset + loc.length));
+	}
+
+	return concatAvcNalUnits(filteredNalUnits, decoderConfig);
+};
+
 /** Builds an AvcDecoderConfigurationRecord from an AVC packet in Annex B format. */
 export const extractAvcDecoderConfigurationRecord = (packetData: Uint8Array): AvcDecoderConfigurationRecord | null => {
 	try {

--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -8,16 +8,13 @@
 
 import { parsePcmCodec, PCM_AUDIO_CODECS, PcmAudioCodec, VideoCodec, AudioCodec } from './codec';
 import {
-	AvcNalUnitType,
-	concatAvcNalUnits,
 	deserializeAvcDecoderConfigurationRecord,
 	determineVideoPacketType,
-	extractNalUnitTypeForAvc,
 	extractNalUnitTypeForHevc,
 	HevcNalUnitType,
-	iterateAvcNalUnits,
 	iterateHevcNalUnits,
 	parseAvcSps,
+	sanitizeAvcPacketForChromium,
 	sanitizeHevcPacketForChromium,
 } from './codec-data';
 import { CustomVideoDecoder, customVideoDecoders, CustomAudioDecoder, customAudioDecoders } from './custom-coder';
@@ -1010,25 +1007,7 @@ class VideoDecoderWrapper extends DecoderWrapper<VideoSample> {
 			if (isChromium() && this.currentPacketIndex === 0) {
 				if (this.codec === 'avc') {
 					// Workaround for https://issues.chromium.org/issues/470109459
-					const filteredNalUnits: Uint8Array[] = [];
-
-					for (const loc of iterateAvcNalUnits(packet.data, this.decoderConfig)) {
-						const type = extractNalUnitTypeForAvc(packet.data[loc.offset]!);
-
-						if (type === AvcNalUnitType.AUD) {
-							// If packets contain an AUD and have NALUs before it, this trips up Chromium's key frame
-							// detector. Clear the NALUs if an AUD is encountered.
-							// https://github.com/Vanilagy/mediabunny/issues/396
-							filteredNalUnits.length = 0;
-						}
-
-						// These trip up Chromium's key frame detection, so let's strip them
-						if (!(type >= 20 && type <= 31)) {
-							filteredNalUnits.push(packet.data.subarray(loc.offset, loc.offset + loc.length));
-						}
-					}
-
-					const newData = concatAvcNalUnits(filteredNalUnits, this.decoderConfig);
+					const newData = sanitizeAvcPacketForChromium(packet.data, this.decoderConfig);
 					packet = new EncodedPacket(newData, packet.type, packet.timestamp, packet.duration);
 				} else if (this.codec === 'hevc') {
 					// Workaround for https://issues.chromium.org/issues/507611247

--- a/test/node/media-sinks.test.ts
+++ b/test/node/media-sinks.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest';
+import {
+	determineVideoPacketType,
+	extractNalUnitTypeForAvc,
+	iterateAvcNalUnits,
+	sanitizeAvcPacketForChromium,
+} from '../../src/codec-data.js';
+
+const AVC_CONFIG: VideoDecoderConfig = {
+	codec: 'avc1.640034',
+	codedWidth: 16,
+	codedHeight: 16,
+	description: new Uint8Array([1, 100, 0, 52, 255, 0]),
+};
+
+const lengthPrefixedNalUnit = (type: number, payloadLength = 1) => {
+	const length = payloadLength + 1;
+	return [
+		(length >>> 24) & 0xff,
+		(length >>> 16) & 0xff,
+		(length >>> 8) & 0xff,
+		length & 0xff,
+		type,
+		...Array.from({ length: payloadLength }, () => 0),
+	];
+};
+
+test('Chromium AVC sanitization preserves IDR frames followed by AUD', () => {
+	const packetData = new Uint8Array([
+		...lengthPrefixedNalUnit(5, 4), // IDR
+		...lengthPrefixedNalUnit(9), // AUD
+	]);
+
+	const sanitizedData = sanitizeAvcPacketForChromium(packetData, AVC_CONFIG);
+	const nalTypes = [...iterateAvcNalUnits(sanitizedData, AVC_CONFIG)]
+		.map(loc => extractNalUnitTypeForAvc(sanitizedData[loc.offset]!));
+
+	expect(nalTypes).toEqual([5, 9]);
+	expect(determineVideoPacketType('avc', AVC_CONFIG, sanitizedData)).toBe('key');
+});


### PR DESCRIPTION
# Preserve AVC IDR frames before AUD during Chromium sanitization

## Summary

This change fixes the Chromium AVC packet sanitization path used by `VideoSampleSink`.

Some valid AVC streams can place an IDR NAL unit before an AUD NAL unit in the first packet. The previous workaround cleared all accumulated NAL units when it encountered an AUD, so a first packet shaped like `[IDR, AUD]` lost the actual key frame data. The packet was still marked as a key packet, but Chromium then rejected it because the encoded chunk no longer contained a key frame.

The fix keeps the existing Chromium workaround scoped to the problematic reserved AVC NAL unit range while preserving valid NAL units that appear before AUD.

## Root Cause

The first Chromium decode packet for AVC was sanitized in `VideoDecoderWrapper` to avoid Chromium key frame detection issues.

Before this patch, the sanitizer did two things:

1. It cleared previously collected NAL units whenever it encountered an AUD.
2. It removed NAL unit types in the `20..31` range.

The AUD clearing behavior was too broad. For streams whose first packet begins with an IDR frame followed by AUD, clearing on AUD removed the IDR frame. This made the `EncodedVideoChunk` metadata say `type: "key"` while the actual bytes no longer contained the key frame.

## Fix

- Move AVC Chromium packet sanitization into `src/codec-data.ts`, next to the other codec-data helpers.
- Stop clearing accumulated AVC NAL units when an AUD is encountered.
- Keep removing AVC NAL unit types `20..31`, preserving the existing Chromium workaround behavior for those units.
- Add a regression test for a length-prefixed AVC packet shaped as `[IDR, AUD]`.

## Testing

Passed locally:

```bash
npm run pre-test && npx vitest --run test/node/media-sinks.test.ts
npm run check
npm run lint
npm run build
```

I also ran the full local test suite:

```bash
npm test
```

The new regression test passed during that run, but the full suite did not complete cleanly in my local environment because unrelated external-network tests timed out or hit `ECONNRESET`:

- `test/node/hls-input.test.ts`
- `test/node/prores.test.ts`

Those failures are in remote HLS/ProRes fixture paths and do not exercise this AVC sanitization change.
