### PR TITLE
Fix AudioResampler crackle at exact rate ratios: 32 kHz -> 48 kHz

### DIFF
--- a/src/resample.ts
+++ b/src/resample.ts
@@ -199,7 +199,7 @@ export class AudioResampler {
 		const inputEndTime = inputStartTime + audioSample.duration;
 
 		// Compute which output frames are affected by this sample
-		const outputStartFrame = Math.floor(inputStartTime * this.targetSampleRate);
+		const outputStartFrame = Math.floor((inputStartTime - 1 / this.sourceSampleRate) * this.targetSampleRate) + 1;
 		const outputEndFrame = Math.ceil(inputEndTime * this.targetSampleRate);
 
 		for (let outputFrame = outputStartFrame; outputFrame < outputEndFrame; outputFrame++) {


### PR DESCRIPTION
## The bug

`AudioResampler.add` interpolates each `AudioSample` chunk in isolation, so source frames outside the current chunk read as 0. At exact rate ratios (32000 → 48000 = 2:3, one 1024-frame chunk = exactly 1536 output frames) chunk boundaries land exactly on output frames: the last output frame of every chunk interpolates toward that phantom zero and is never rewritten — a periodic dip, audible as constant crackle. Non-integral ratios (44.1k → 48k) mask this: both chunks write the boundary frame with complementary weights via the `+=` overlap-add.

## The fix

Start each chunk's output range one source frame earlier: those frames interpolate against the chunk's first frame with exactly the weight the previous chunk left missing, making the interpolation exact across boundaries. Non-integral ratios compute the same start frame as before; the first chunk's negative frames are already skipped by the `outputFrame < this.bufferStartFrame` guard.

## Testing

- 440 Hz sine at 32 kHz through `AudioResampler` in 1024-frame chunks → 48 kHz: worst deviation from the ideal resampled sine drops from 0.334 to 0.0008
- `npm run test-node`: 287 passed; `tsc -p src` and `eslint` clean
- Running in production as a package patch — 32 kHz proxy transcodes are crackle-free