### PR TITLE
feat: allow passing external audio source to Conversion API

### DIFF
--- a/examples/external-audio/external-audio.ts
+++ b/examples/external-audio/external-audio.ts
@@ -1,0 +1,100 @@
+import { 
+	Conversion, 
+	AudioSampleSource, 
+	AudioSample 
+} from '../../src/index';
+
+const selectFileBtn = document.getElementById('select-file') as HTMLButtonElement;
+const fileNameEl = document.getElementById('file-name') as HTMLParagraphElement;
+const loadingEl = document.getElementById('loading') as HTMLDivElement;
+const resultEl = document.getElementById('result') as HTMLDivElement;
+const outputVideo = document.getElementById('output-video') as HTMLVideoElement;
+const downloadLink = document.getElementById('download-link') as HTMLAnchorElement;
+const errorEl = document.getElementById('error-message') as HTMLDivElement;
+
+selectFileBtn.addEventListener('click', async () => {
+	const file = await selectFile();
+	if (!file) return;
+
+	fileNameEl.textContent = `Selected: ${file.name}`;
+	loadingEl.classList.remove('hidden');
+	resultEl.classList.add('hidden');
+	errorEl.classList.add('hidden');
+
+	try {
+		// 1. Set up a synthesized audio source using AudioSampleSource
+		const sampleRate = 48000;
+		const durationSeconds = 5;
+		const audioSource = new AudioSampleSource({
+			codec: 'aac',
+			bitrate: 128_000,
+			transform: {
+				numberOfChannels: 1,
+				sampleRate,
+				sampleFormat: 'f32-planar'
+			}
+		});
+
+		// 2. Perform the conversion
+		const conversion = await Conversion.start({
+			input: file,
+			output: {
+				format: 'mp4'
+			},
+			tracks: 'primary',
+			// Pass our custom audio source to be multiplexed!
+			externalAudioSource: audioSource
+		});
+
+		// 3. Generate some audio samples (a simple beep) while it's muxing
+		const frequency = 440;
+		const samples = new Float32Array(sampleRate * durationSeconds);
+		for (let i = 0; i < samples.length; i++) {
+			samples[i] = Math.sin(2 * Math.PI * frequency * (i / sampleRate));
+		}
+		
+		const sample = new AudioSample({
+			data: samples,
+			format: 'f32-planar',
+			numberOfChannels: 1,
+			sampleRate,
+			timestamp: 0
+		});
+		
+		// Wait for the track to be ready before adding samples
+		await audioSource.add(sample);
+		audioSource.close();
+		sample.close();
+
+		// 4. Wait for conversion to finish
+		const result = await conversion.buffer;
+
+		// 5. Display the result
+		const blob = new Blob([result], { type: 'video/mp4' });
+		const url = URL.createObjectURL(blob);
+		
+		outputVideo.src = url;
+		downloadLink.href = url;
+		downloadLink.download = `external-audio-${file.name}`;
+		
+		loadingEl.classList.add('hidden');
+		resultEl.classList.remove('hidden');
+	} catch (error) {
+		console.error(error);
+		errorEl.textContent = String(error);
+		errorEl.classList.remove('hidden');
+		loadingEl.classList.add('hidden');
+	}
+});
+
+async function selectFile(): Promise<File | null> {
+	return new Promise((resolve) => {
+		const input = document.createElement('input');
+		input.type = 'file';
+		input.accept = 'video/*';
+		input.onchange = () => {
+			resolve(input.files?.[0] || null);
+		};
+		input.click();
+	});
+}

--- a/examples/external-audio/index.html
+++ b/examples/external-audio/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en-US" translate="no">
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>External audio source example | Mediabunny</title>
+		<meta name="description" content="Add a generated audio track to a video using the Conversion API's externalAudioSource option.">
+		<script type="module" src="../base.ts"></script>
+		<script type="module" src="./external-audio.ts"></script>
+		<link rel="stylesheet" href="../base.css">
+		<link rel="icon" href="../../docs/public/mediabunny-logo.svg">
+	</head>
+
+	<body class="flex flex-col items-center py-10 bg-zinc-50 text-zinc-800 dark:bg-zinc-900 dark:text-zinc-200 px-2">
+		<h1 class="text-3xl font-bold text-teal-500 text-center">External audio source</h1>
+		<p class="max-w-lg text-center mt-2">Select a video file. Mediabunny will generate a synthesized beep track and multiplex it into the video using the <code>externalAudioSource</code> option in the <code>Conversion</code> API.</p>
+
+		<div class="flex flex-col items-center gap-1 mt-4">
+			<button id="select-file" class="rounded-lg bg-zinc-200 dark:bg-zinc-750 hover:bg-zinc-300 dark:hover:bg-zinc-700 px-5 py-2">
+				Select video file
+			</button>
+		</div>
+
+		<p class="text-xs opacity-60 mt-2 mx-auto text-center max-w-[36rem]" id="file-name"></p>
+
+		<div id="loading" class="hidden mt-8 flex flex-col items-center gap-4">
+			<div class="w-8 h-8 border-4 border-teal-500 border-t-transparent rounded-full animate-spin"></div>
+			<p class="animate-pulse">Processing media...</p>
+		</div>
+
+		<div id="result" class="hidden mt-8 flex flex-col items-center gap-4 w-full max-w-2xl">
+			<video id="output-video" class="w-full rounded-lg shadow-lg bg-black" controls></video>
+			<a id="download-link" class="rounded-lg bg-teal-500 text-white hover:bg-teal-600 px-5 py-2 font-medium">
+				Download MP4
+			</a>
+		</div>
+
+		<div id="error-message" class="hidden mt-8 text-red-500 text-center max-w-lg bg-red-500/10 p-4 rounded-lg"></div>
+	</body>
+</html>

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -146,6 +146,12 @@ export type ConversionOptions = {
 	 * want to keep the console output clean.
 	 */
 	showWarnings?: boolean;
+
+	/**
+	 * An optional external audio source (e.g. an AudioBufferSource) that will be multiplexed alongside the video.
+	 * If provided, this bypasses the requirement for the original input to have a primary audio track.
+	 */
+	externalAudioSource?: AudioSource;
 };
 
 /**
@@ -884,6 +890,17 @@ export class Conversion {
 				} else {
 					assert(false);
 				}
+			}
+		}
+
+		if (this._options.externalAudioSource) {
+			if (
+				this._totalTrackCount < outputTrackCounts.total.max
+				&& this._addedCounts.audio < outputTrackCounts.audio.max
+			) {
+				this.output.addAudioTrack(this._options.externalAudioSource);
+				this._addedCounts.audio++;
+				this._totalTrackCount++;
 			}
 		}
 


### PR DESCRIPTION
This PR makes a small tweak to the `Conversion` pipeline so we can easily add audio to silent videos.

**use case**
We're building an app that adds synthesized AI voiceovers to screen recordings (which often don't have an initial audio track). Without this option, we had to abandon the nice `Conversion` API and manually wire up `EncodedPacketSink` and `Output` just to multiplex an external audio buffer. 

**approach**
- Added `externalAudioSource` to `ConversionOptions`.
- If provided, we inject it directly into the `Output` multiplexer at the end of the track initialization loop.
- This bypasses the `input.getPrimaryAudioTrack()` validation failures, letting the multiplexing happen seamlessly alongside the video!

edit - **trimming behavior**
Since an `externalAudioSource` is typically an `AudioSampleSource` where the developer pushes samples manually, this source currently bypasses the internal `ConversionOptions.trim` math. The developer remains responsible for only generating/pushing the audio samples that fit within their desired trim window.

I also added a quick interactive demo in `examples/external-audio` so you can see it in action (it generates a procedural beep and muxes it over a selected video).

Let me know if you'd prefer this configured differently. Happy to adjust!
