### PR TITLE
feat: allow passing external audio source to Conversion API

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -50,4 +50,10 @@ features:
       target: _self
       icon:
         src: /mingcute--live-line.svg
+    - title: External audio track
+      details: Attach a synthesized voiceover track to a video without Mediabunny owning the output file.
+      link: /examples/external-audio/
+      target: _self
+      icon:
+        src: /mingcute--microphone-line.svg
 ---

--- a/examples/external-audio/external-audio.ts
+++ b/examples/external-audio/external-audio.ts
@@ -1,0 +1,253 @@
+import {
+	Input,
+	ALL_FORMATS,
+	BlobSource,
+	UrlSource,
+	Output,
+	BufferTarget,
+	Mp4OutputFormat,
+	Conversion,
+	AudioBufferSource,
+} from 'mediabunny';
+
+import SampleFileUrl from '../../docs/assets/big-buck-bunny-trimmed.mp4';
+(document.querySelector('#sample-file-download') as HTMLAnchorElement).href = SampleFileUrl;
+
+const selectMediaButton = document.querySelector('#select-file') as HTMLButtonElement;
+const loadUrlButton = document.querySelector('#load-url') as HTMLButtonElement;
+const fileNameElement = document.querySelector('#file-name') as HTMLParagraphElement;
+const horizontalRule = document.querySelector('hr') as HTMLHRElement;
+const progressBarContainer = document.querySelector('#progress-bar-container') as HTMLDivElement;
+const progressBar = document.querySelector('#progress-bar') as HTMLDivElement;
+const statusText = document.querySelector('#status-text') as HTMLParagraphElement;
+const videoElement = document.querySelector('video') as HTMLVideoElement;
+const resultInfo = document.querySelector('#result-info') as HTMLParagraphElement;
+const errorElement = document.querySelector('#error-element') as HTMLParagraphElement;
+
+let currentConversion: Conversion | null = null;
+let currentOutput: Output<Mp4OutputFormat, BufferTarget> | null = null;
+let currentIntervalId = -1;
+
+/**
+ * Synthesizes a short, speech-cadenced sequence of frequency-swept tones using an OfflineAudioContext. This stands
+ * in for a real text-to-speech voiceover: in a production app, `audioBuffer` would instead come from an AI
+ * voiceover/TTS service, decoded into an AudioBuffer.
+ */
+const synthesizeVoiceover = async (duration: number): Promise<AudioBuffer> => {
+	const sampleRate = 48000;
+	const totalSamples = Math.max(1, Math.ceil(duration * sampleRate));
+	// Two channels, since not every AAC encoder implementation supports mono output.
+	const context = new OfflineAudioContext(2, totalSamples, sampleRate);
+
+	const master = context.createGain();
+	master.gain.value = 0.5;
+	master.connect(context.destination);
+
+	// A tiny deterministic PRNG (mulberry32) so the "voiceover" is reproducible across runs of the demo.
+	let seed = 0x2f6e2b1;
+	const nextRandom = () => {
+		seed = (seed + 0x6d2b79f5) | 0;
+		let x = seed;
+		x = Math.imul(x ^ (x >>> 15), x | 1);
+		x ^= x + Math.imul(x ^ (x >>> 7), x | 61);
+		return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+	};
+
+	// Fill the buffer with short "phrases": frequency sweeps shaped by an envelope and separated by silence, which
+	// roughly mimics the rhythm of spoken words without requiring any real speech synthesis.
+	let t = 0.2;
+	while (t < duration - 0.15) {
+		const phraseDuration = 0.15 + nextRandom() * 0.35;
+		const startFrequency = 120 + nextRandom() * 80;
+		const endFrequency = startFrequency + (nextRandom() - 0.5) * 160;
+
+		const oscillator = context.createOscillator();
+		oscillator.type = 'sawtooth';
+		oscillator.frequency.setValueAtTime(startFrequency, t);
+		oscillator.frequency.linearRampToValueAtTime(endFrequency, t + phraseDuration);
+
+		const lowpass = context.createBiquadFilter();
+		lowpass.type = 'lowpass';
+		lowpass.frequency.value = 1200;
+
+		const envelope = context.createGain();
+		envelope.gain.setValueAtTime(0, t);
+		envelope.gain.linearRampToValueAtTime(1, t + phraseDuration * 0.2);
+		envelope.gain.linearRampToValueAtTime(1, t + phraseDuration * 0.7);
+		envelope.gain.linearRampToValueAtTime(0, t + phraseDuration);
+
+		oscillator.connect(lowpass);
+		lowpass.connect(envelope);
+		envelope.connect(master);
+
+		oscillator.start(t);
+		oscillator.stop(t + phraseDuration);
+
+		t += phraseDuration + 0.08 + nextRandom() * 0.25; // Gap before the next "word"
+	}
+
+	return context.startRendering();
+};
+
+const addVoiceover = async (resource: File | string) => {
+	clearInterval(currentIntervalId);
+	await currentConversion?.cancel();
+	// The conversion we're about to create won't own the output, so canceling it won't touch the output. We're the
+	// ones who own it, so we must cancel any leftover output from a previous run ourselves.
+	await currentOutput?.cancel();
+
+	fileNameElement.textContent = resource instanceof File ? resource.name : resource;
+	horizontalRule.style.display = '';
+	progressBarContainer.style.display = '';
+	progressBar.style.width = '0%';
+	statusText.style.display = '';
+	statusText.textContent = 'Loading video...';
+	videoElement.style.display = 'none';
+	videoElement.src = '';
+	resultInfo.style.display = 'none';
+	errorElement.textContent = '';
+
+	try {
+		// Create a new input from the resource
+		const source = resource instanceof File
+			? new BlobSource(resource)
+			: new UrlSource(resource);
+		const input = new Input({
+			source,
+			formats: ALL_FORMATS, // Accept all formats
+		});
+
+		// Define the output file. Since we're using `ownsOutput: false`, this Output is entirely ours: we're the
+		// ones who start it, add tracks to it, and finalize it.
+		const output = new Output({
+			target: new BufferTarget(),
+			format: new Mp4OutputFormat(),
+		});
+		currentOutput = output;
+
+		// A non-owning conversion only pumps the tracks it's given into the output; here, that's just the video
+		// track. Any audio the input might already have is discarded, since we're replacing it with our own
+		// synthesized voiceover track. If the input has no audio to begin with, this is a no-op.
+		currentConversion = await Conversion.init({
+			input,
+			output,
+			ownsOutput: false,
+			audio: { discard: true },
+		});
+
+		if (!currentConversion.isValid) {
+			console.info(currentConversion.discardedTracks);
+			throw new Error('Conversion is invalid and cannot be executed; see the console for more.');
+		}
+
+		// We add our own audio track directly to the output; the conversion never touches it, nor does it write
+		// any metadata tags (a non-owning conversion always leaves both of those to us).
+		const voiceoverSource = new AudioBufferSource({ codec: 'aac', bitrate: 128e3 });
+		output.addAudioTrack(voiceoverSource);
+
+		// Keep track of conversion progress
+		let progress = 0;
+		currentConversion.onProgress = (newProgress) => {
+			progress = newProgress;
+		};
+
+		const updateProgress = () => {
+			progressBar.style.width = `${progress * 100}%`;
+		};
+		currentIntervalId = window.setInterval(updateProgress, 1000 / 60);
+
+		// A non-owning conversion requires the output to already be started before `execute()` may be called, since
+		// tracks (like the one we just added) can only be added while the output is still pending.
+		await output.start();
+
+		// Synthesize a voiceover track as long as the video itself
+		statusText.textContent = 'Synthesizing voiceover...';
+		const duration = await input.computeDuration();
+		const voiceoverBuffer = await synthesizeVoiceover(Math.max(duration, 0.5));
+
+		statusText.textContent = 'Converting...';
+
+		// Run the conversion (which pumps the video track) concurrently with feeding our own voiceover audio into
+		// the output. Both write into the very same output file.
+		await Promise.all([
+			currentConversion.execute(),
+			(async () => {
+				await voiceoverSource.add(voiceoverBuffer);
+				voiceoverSource.close();
+			})(),
+		]);
+
+		// Since the conversion doesn't own the output, finalizing it is our responsibility.
+		await output.finalize();
+
+		clearInterval(currentIntervalId);
+		updateProgress();
+		statusText.style.display = 'none';
+
+		// Display the final media file
+		videoElement.style.display = '';
+		videoElement.src = URL.createObjectURL(new Blob([output.target.buffer!], { type: output.format.mimeType }));
+		void videoElement.play();
+
+		resultInfo.style.display = '';
+		resultInfo.textContent = `Added a ${duration.toFixed(1)} s synthesized voiceover track.`;
+	} catch (error) {
+		console.error(error);
+
+		await currentConversion?.cancel();
+		await currentOutput?.cancel();
+
+		errorElement.textContent = String(error);
+		clearInterval(currentIntervalId);
+
+		progressBarContainer.style.display = 'none';
+		statusText.style.display = 'none';
+		resultInfo.style.display = 'none';
+		videoElement.style.display = 'none';
+	}
+};
+
+/** === FILE SELECTION LOGIC === */
+
+selectMediaButton.addEventListener('click', () => {
+	const fileInput = document.createElement('input');
+	fileInput.type = 'file';
+	fileInput.accept = 'video/*,video/x-matroska,video/mp2t,.ts';
+	fileInput.addEventListener('change', () => {
+		const file = fileInput.files?.[0];
+		if (!file) {
+			return;
+		}
+
+		void addVoiceover(file);
+	});
+
+	fileInput.click();
+});
+
+loadUrlButton.addEventListener('click', () => {
+	const url = prompt(
+		'Please enter a URL of a video file. Note that it must be HTTPS and support cross-origin requests, so have the'
+		+ ' right CORS headers set.',
+		'https://mediabunny.dev/big-buck-bunny.mp4',
+	);
+	if (!url) {
+		return;
+	}
+
+	void addVoiceover(url);
+});
+
+document.addEventListener('dragover', (event) => {
+	event.preventDefault();
+	event.dataTransfer!.dropEffect = 'copy';
+});
+
+document.addEventListener('drop', (event) => {
+	event.preventDefault();
+	const files = event.dataTransfer?.files;
+	const file = files && files.length > 0 ? files[0] : undefined;
+	if (file) {
+		void addVoiceover(file);
+	}
+});

--- a/examples/external-audio/index.html
+++ b/examples/external-audio/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en-US" translate="no">
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>External audio track example | Mediabunny</title>
+		<meta name="description" content="Select or drop a video file, and Mediabunny will attach a synthesized voiceover-like audio track to it without taking ownership of the output file.">
+		<script type="module" src="../base.ts"></script>
+		<script type="module" src="./external-audio.ts"></script>
+		<link rel="stylesheet" href="../base.css">
+		<link rel="icon" href="../../docs/public/mediabunny-logo.svg">
+		<link rel="canonical" href="https://mediabunny.dev/examples/external-audio/">
+		<meta property="og:site_name" content="Mediabunny">
+		<meta property="og:type" content="website">
+		<meta property="og:title" content="External audio track example | Mediabunny">
+		<meta property="og:description" content="Select or drop a video file, and Mediabunny will attach a synthesized voiceover-like audio track to it without taking ownership of the output file.">
+		<meta property="og:url" content="https://mediabunny.dev/examples/external-audio/">
+		<meta property="og:image" content="https://mediabunny.dev/mediabunny-og-image.png">
+		<meta property="og:locale" content="en-US">
+		<meta name="twitter:card" content="summary_large_image">
+		<meta name="twitter:site" content="@vanilagy">
+		<meta name="twitter:title" content="External audio track example | Mediabunny">
+		<meta name="twitter:description" content="Select or drop a video file, and Mediabunny will attach a synthesized voiceover-like audio track to it without taking ownership of the output file.">
+		<meta name="twitter:image" content="https://mediabunny.dev/mediabunny-og-image.png">
+		<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Examples","item":"https://mediabunny.dev/examples"},{"@type":"ListItem","position":2,"name":"External audio track"}]}</script>
+	</head>
+
+	<body class="flex flex-col items-center py-10 bg-zinc-50 text-zinc-800 dark:bg-zinc-900 dark:text-zinc-200 px-2">
+		<h1 class="text-3xl font-bold text-violet-500 text-center">External audio track example</h1>
+		<p class="max-w-lg text-center">
+			Select or drop a video file (with or without audio), and Mediabunny will synthesize a short
+			voiceover-like audio track and attach it to the video. The conversion doesn't own the output file here —
+			we do, and we add the new audio track ourselves.
+		</p>
+
+		<div class="flex flex-col items-center gap-1">
+			<div class="flex gap-2 mt-4">
+				<button id="select-file" class="rounded-lg bg-zinc-200 dark:bg-zinc-750 hover:bg-zinc-300 dark:hover:bg-zinc-700 px-5 py-2">
+					Select local file
+				</button>
+
+				<button id="load-url" class="rounded-lg bg-zinc-200 dark:bg-zinc-750 hover:bg-zinc-300 dark:hover:bg-zinc-700 px-5 py-2">
+					Load remote URL
+				</button>
+			</div>
+
+			<a id="sample-file-download" download="big-buck-bunny-trimmed.mp4" class="hover:underline text-xs opacity-50 hover:opacity-70">
+				Download sample file
+			</a>
+		</div>
+
+		<p class="text-xs opacity-60 mt-2 mx-auto text-center max-w-[36rem]" id="file-name"></p>
+
+		<hr class="w-full max-w-96 my-4 border-zinc-300 dark:border-zinc-700" style="display: none;">
+
+		<p id="error-element" class="text-red-500 mx-auto text-center max-w-[36rem]"></p>
+
+		<div class="w-full max-w-80 h-2 rounded-full bg-zinc-200 dark:bg-zinc-750 overflow-hidden" id="progress-bar-container" style="display: none;">
+			<div class="h-full bg-violet-500 w-0" id="progress-bar"></div>
+		</div>
+		<p class="text-xs font-medium mt-1" id="status-text" style="display: none;"></p>
+
+		<video controls class="rounded-md mt-4" style="display: none;"></video>
+		<p class="text-xs font-medium mt-1" id="result-info" style="display: none;"></p>
+
+		<a href="/" class="fixed top-0 left-0 flex gap-2 py-2 px-5 items-center">
+			<img src="../../docs/public/mediabunny-logo.svg" class="size-6">
+			<p class="text-sm font-medium">Mediabunny</p>
+		</a>
+
+		<a
+			href="https://github.com/Vanilagy/mediabunny/tree/main/examples/external-audio"
+			target="_blank"
+			class="flex items-center gap-2 fixed top-0 right-0 py-2 px-5 bg-zinc-200 dark:bg-zinc-750 hover:bg-zinc-300 dark:hover:bg-zinc-700 rounded-bl-xl"
+		>
+			<img src="../../docs/assets/github-mark.svg" class="size-6 dark:invert">
+			<p>View source code</p>
+		</a>
+	</body>
+</html>

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -33,6 +33,7 @@ import {
 	AudioSource,
 	EncodedVideoPacketSource,
 	EncodedAudioPacketSource,
+	MediaSource,
 	VideoSource,
 	VideoSampleSource,
 	AudioSampleSource,
@@ -146,6 +147,15 @@ export type ConversionOptions = {
 	 * want to keep the console output clean.
 	 */
 	showWarnings?: boolean;
+
+	/**
+	 * Whether this conversion takes full ownership of the output, defaults to `true`. An owning conversion requires
+	 * a fresh output and controls its entire lifecycle: it starts it, writes its metadata tags, and finalizes it.
+	 * A non-owning conversion only adds tracks to the output and drives their media data; starting and finalizing
+	 * the output remain your responsibility, and additional tracks (or other non-owning conversions) may be attached
+	 * to the same output.
+	 */
+	ownsOutput?: boolean;
 };
 
 /**
@@ -564,6 +574,10 @@ export class Conversion {
 
 	/** @internal */
 	_trackPromises: Promise<void>[] = [];
+	/** @internal */
+	_ownsOutput = true;
+	/** @internal */
+	_sources: MediaSource[] = [];
 
 	/** @internal */
 	_started: Promise<void>;
@@ -642,12 +656,32 @@ export class Conversion {
 				'options.tracks, when provided, must be either \'all\' or \'primary\'.',
 			);
 		}
-		if (
-			options.output._tracks.length > 0
-			|| Object.keys(options.output._metadataTags).length > 0
-			|| options.output.state !== 'pending'
-		) {
-			throw new TypeError('options.output must be fresh: no tracks or metadata tags added and not started.');
+		if (options.ownsOutput !== undefined && typeof options.ownsOutput !== 'boolean') {
+			throw new TypeError('options.ownsOutput, when provided, must be a boolean.');
+		}
+
+		const ownsOutput = options.ownsOutput ?? true;
+
+		if (!ownsOutput && options.tags !== undefined) {
+			throw new TypeError(
+				'options.tags cannot be set by a non-owning conversion; set metadata directly on the output instead.',
+			);
+		}
+
+		if (ownsOutput) {
+			if (
+				options.output._tracks.length > 0
+				|| Object.keys(options.output._metadataTags).length > 0
+				|| options.output.state !== 'pending'
+			) {
+				throw new TypeError('options.output must be fresh: no tracks or metadata tags added and not started.');
+			}
+		} else if (options.output.state !== 'pending') {
+			// A non-owning conversion only adds tracks, which can only happen before the output has started.
+			// Pre-existing tracks and metadata tags are explicitly allowed.
+			throw new TypeError(
+				'options.output must not have been started yet; tracks can only be added before the output starts.',
+			);
 		}
 
 		if (options.video !== undefined && typeof options.video !== 'function') {
@@ -704,6 +738,7 @@ export class Conversion {
 		}
 
 		this._options = options;
+		this._ownsOutput = ownsOutput;
 		this.input = options.input;
 		this.output = options.output;
 
@@ -741,6 +776,15 @@ export class Conversion {
 		}
 
 		const outputTrackCounts = this.output.format.getSupportedTrackCounts();
+
+		if (!this._ownsOutput) {
+			// Seed the track counts from the tracks already present on the output, so that the max-track-count discard
+			// logic is computed against the format's remaining capacity.
+			for (const existingTrack of this.output._tracks) {
+				this._addedCounts[existingTrack.type]++;
+				this._totalTrackCount++;
+			}
+		}
 
 		// Input track counters
 		let nVideo = 1;
@@ -906,39 +950,48 @@ export class Conversion {
 			}
 		}
 
-		// Now, let's deal with metadata tags
+		// Now, let's deal with metadata tags. A non-owning conversion does not touch the output's metadata tags; that
+		// remains the responsibility of whoever owns the output.
 
-		const inputTags = await this.input.getMetadataTags();
-		let outputTags: MetadataTags;
+		if (this._ownsOutput) {
+			const inputTags = await this.input.getMetadataTags();
+			let outputTags: MetadataTags;
 
-		if (this._options.tags) {
-			const result = typeof this._options.tags === 'function'
-				? await this._options.tags(inputTags)
-				: this._options.tags;
-			validateMetadataTags(result);
+			if (this._options.tags) {
+				const result = typeof this._options.tags === 'function'
+					? await this._options.tags(inputTags)
+					: this._options.tags;
+				validateMetadataTags(result);
 
-			outputTags = result;
-		} else {
-			outputTags = inputTags;
+				outputTags = result;
+			} else {
+				outputTags = inputTags;
+			}
+
+			// Somewhat dirty but pragmatic
+			const inputAndOutputFormatMatch = inputFormat.mimeType === this.output.format.mimeType;
+			const rawTagsAreUnchanged = inputTags.raw === outputTags.raw;
+
+			if (inputTags.raw && rawTagsAreUnchanged && !inputAndOutputFormatMatch) {
+				// If the input and output formats aren't the same, copying over raw metadata tags makes no sense and
+				// only results in junk tags, so let's cut them out.
+				delete outputTags.raw;
+			}
+
+			this.output.setMetadataTags(outputTags);
 		}
-
-		// Somewhat dirty but pragmatic
-		const inputAndOutputFormatMatch = inputFormat.mimeType === this.output.format.mimeType;
-		const rawTagsAreUnchanged = inputTags.raw === outputTags.raw;
-
-		if (inputTags.raw && rawTagsAreUnchanged && !inputAndOutputFormatMatch) {
-			// If the input and output formats aren't the same, copying over raw metadata tags makes no sense and only
-			// results in junk tags, so let's cut them out.
-			delete outputTags.raw;
-		}
-
-		this.output.setMetadataTags(outputTags);
 
 		// Let's check if the conversion can actually be executed
-		this.isValid = this._totalTrackCount >= outputTrackCounts.total.min
-			&& this._addedCounts.video >= outputTrackCounts.video.min
-			&& this._addedCounts.audio >= outputTrackCounts.audio.min
-			&& this._addedCounts.subtitle >= outputTrackCounts.subtitle.min;
+		if (this._ownsOutput) {
+			this.isValid = this._totalTrackCount >= outputTrackCounts.total.min
+				&& this._addedCounts.video >= outputTrackCounts.video.min
+				&& this._addedCounts.audio >= outputTrackCounts.audio.min
+				&& this._addedCounts.subtitle >= outputTrackCounts.subtitle.min;
+		} else {
+			// A conversion contributing zero tracks is invalid. The format's minimum track counts are not checked here,
+			// since `Output.start()` enforces those against the full track set.
+			this.isValid = this.utilizedTracks.length > 0;
+		}
 
 		if (this._options.showWarnings ?? true) {
 			const warnElements: unknown[] = [];
@@ -1054,6 +1107,13 @@ export class Conversion {
 			);
 		}
 
+		if (!this._ownsOutput && this.output.state === 'pending') {
+			throw new Error(
+				'A non-owning conversion requires the output to be started. Call output.start() before executing the'
+				+ ' conversion.',
+			);
+		}
+
 		if (this._executed) {
 			throw new Error('Conversion cannot be executed twice.');
 		}
@@ -1088,7 +1148,10 @@ export class Conversion {
 			this.onProgress?.(0, 0);
 		}
 
-		await this.output.start();
+		if (this._ownsOutput) {
+			await this.output.start();
+		}
+
 		this._start();
 
 		try {
@@ -1106,7 +1169,9 @@ export class Conversion {
 			throw new ConversionCanceledError();
 		}
 
-		await this.output.finalize();
+		if (this._ownsOutput) {
+			await this.output.finalize();
+		}
 
 		if (this._computeProgress) {
 			const minTimestamp = Math.min(...this._maxTimestamps.values());
@@ -1129,7 +1194,17 @@ export class Conversion {
 		}
 
 		this._canceled = true;
-		await this.output.cancel();
+
+		if (this._ownsOutput) {
+			await this.output.cancel();
+		} else {
+			// A non-owning conversion must not cancel the output. Release any pump loops that are parked in the
+			// synchronizer (the output stays alive, so they'd otherwise hang forever), then force-close only the
+			// sources this conversion created. This leaves the output usable for its owner.
+			this._synchronizer.releaseAll();
+
+			await Promise.all(this._sources.map(source => source._flushOrWaitForOngoingClose(true)));
+		}
 	}
 
 	/** @internal */
@@ -1402,7 +1477,9 @@ export class Conversion {
 		}
 
 		let ownGroup: OutputTrackGroup | null = null;
-		if (!trackOptions.group) {
+		if (!trackOptions.group && this._ownsOutput) {
+			// Only owning conversions create per-track own groups to replicate the input's pairability graph. For
+			// non-owning conversions, tracks without a user-provided group fall into `Output.defaultTrackGroup`.
 			ownGroup = new OutputTrackGroup();
 		}
 
@@ -1419,6 +1496,7 @@ export class Conversion {
 		this._addedCounts.video++;
 		this._totalTrackCount++;
 
+		this._sources.push(videoSource);
 		this.utilizedTracks.push(track);
 		this._outputTrackIds.push(outputTrackId);
 		this._outputOwnTrackGroups.push(ownGroup);
@@ -1660,7 +1738,9 @@ export class Conversion {
 		}
 
 		let ownGroup: OutputTrackGroup | null = null;
-		if (!trackOptions.group) {
+		if (!trackOptions.group && this._ownsOutput) {
+			// Only owning conversions create per-track own groups to replicate the input's pairability graph. For
+			// non-owning conversions, tracks without a user-provided group fall into `Output.defaultTrackGroup`.
 			ownGroup = new OutputTrackGroup();
 		}
 
@@ -1675,6 +1755,7 @@ export class Conversion {
 		this._addedCounts.audio++;
 		this._totalTrackCount++;
 
+		this._sources.push(audioSource);
 		this.utilizedTracks.push(track);
 		this._outputTrackIds.push(outputTrackId);
 		this._outputOwnTrackGroups.push(ownGroup);
@@ -1750,6 +1831,8 @@ class TrackSynchronizer {
 		resolve: () => void;
 	}[] = [];
 
+	released = false;
+
 	declareTrack(trackId: number) {
 		this.maxTimestamps.set(trackId, 0);
 	}
@@ -1765,6 +1848,11 @@ class TrackSynchronizer {
 	}
 
 	wait(timestamp: number) {
+		if (this.released) {
+			// Already released (e.g. due to a non-owning cancel); don't park, so the pump can run to its cancel check.
+			return Promise.resolve();
+		}
+
 		const { promise, resolve } = promiseWithResolvers();
 
 		this.resolvers.push({
@@ -1778,6 +1866,19 @@ class TrackSynchronizer {
 	closeTrack(trackId: number) {
 		this.maxTimestamps.delete(trackId);
 		this.computeMinAndMaybeResolve();
+	}
+
+	releaseAll() {
+		// Resolve and clear all pending waiters, and ensure future `wait` calls don't park either. Used when a
+		// non-owning conversion is canceled: the output stays alive, so pump loops parked in (or about to enter) `wait`
+		// must be released to let them run to their `_canceled` check and exit.
+		this.released = true;
+
+		for (const entry of this.resolvers) {
+			entry.resolve();
+		}
+
+		this.resolvers.length = 0;
 	}
 
 	computeMinAndMaybeResolve() {

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -1185,6 +1185,16 @@ export class Conversion {
 	 */
 	async cancel() {
 		if (this.output.state === 'finalizing' || this.output.state === 'finalized') {
+			if (!this._ownsOutput && !this._canceled) {
+				// The output (owned by someone else) has already moved on to finalizing/finalized while this
+				// conversion was still pumping. We must still mark ourselves canceled and release any pump loops
+				// parked in the synchronizer, or `execute()` would hang forever waiting on `wait()` that never
+				// resolves. We must NOT force-close this conversion's sources here, since finalization already
+				// owns flushing them at this point.
+				this._canceled = true;
+				this._synchronizer.releaseAll();
+			}
+
 			return;
 		}
 

--- a/test/node/conversion.test.ts
+++ b/test/node/conversion.test.ts
@@ -1,0 +1,292 @@
+import { expect, test } from 'vitest';
+import path from 'node:path';
+import { Input } from '../../src/input.js';
+import { ALL_FORMATS } from '../../src/input-format.js';
+import { BufferSource, FilePathSource } from '../../src/source.js';
+import { Output } from '../../src/output.js';
+import { Mp4OutputFormat, WavOutputFormat } from '../../src/output-format.js';
+import { BufferTarget } from '../../src/target.js';
+import { Conversion, ConversionCanceledError } from '../../src/conversion.js';
+import { EncodedAudioPacketSource } from '../../src/media-source.js';
+import { EncodedPacket } from '../../src/packet.js';
+
+const publicDir = path.join(new URL('.', import.meta.url).pathname, '../public');
+const videoPath = path.join(publicDir, 'video.mp4'); // avc video + aac audio, ~5 s, has metadata tags
+const wavPath = path.join(publicDir, 'glitch-hop-is-dead.wav'); // pcm-s16 audio
+
+// eslint-disable-next-line @stylistic/max-len
+const aacPacketData = new Uint8Array([255, 241, 77, 128, 3, 159, 252, 0, 208, 0, 1, 3, 64, 0, 13, 0, 0, 17, 52, 0, 0, 208, 0, 3, 6, 128, 0, 56]);
+const aacMetadata: EncodedAudioChunkMetadata = {
+	decoderConfig: {
+		codec: 'mp4a.40.2',
+		numberOfChannels: 2,
+		sampleRate: 48000,
+	},
+};
+
+const addAacPackets = async (source: EncodedAudioPacketSource, durationSeconds: number) => {
+	const packetDuration = 1024 / 48000;
+	const count = Math.ceil(durationSeconds / packetDuration);
+	for (let i = 0; i < count; i++) {
+		await source.add(
+			new EncodedPacket(aacPacketData, 'key', i * packetDuration, packetDuration),
+			i === 0 ? aacMetadata : undefined,
+		);
+	}
+};
+
+const makeInput = () => new Input({ source: new FilePathSource(videoPath), formats: ALL_FORMATS });
+
+test('Owning conversion still requires a fresh output', async () => {
+	using input = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+	output.addAudioTrack(new EncodedAudioPacketSource('aac')); // Makes the output non-fresh
+
+	await expect(Conversion.init({ input, output })).rejects.toThrow(/must be fresh/);
+});
+
+test('Non-owning init works on an output that already has a track, but not on a started one', async () => {
+	using input = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+	output.addAudioTrack(new EncodedAudioPacketSource('aac')); // A user-added track
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		ownsOutput: false,
+		audio: { discard: true }, // Only contribute the video track
+		showWarnings: false,
+	});
+	expect(conversion.isValid).toBe(true);
+	expect(conversion.utilizedTracks).toHaveLength(1);
+	expect(conversion.utilizedTracks[0]!.type).toBe('video');
+
+	// A started output must be rejected, since tracks can only be added before starting
+	using startedInput = makeInput();
+	const startedOutput = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+	startedOutput.addAudioTrack(new EncodedAudioPacketSource('aac'));
+	await startedOutput.start();
+
+	await expect(Conversion.init({ input: startedInput, output: startedOutput, ownsOutput: false }))
+		.rejects.toThrow(/not have been started/);
+
+	await startedOutput.cancel();
+});
+
+test('Non-owning conversion rejects tags and non-boolean ownsOutput', async () => {
+	using input = makeInput();
+
+	const makeOutput = () => new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	await expect(Conversion.init({
+		input,
+		output: makeOutput(),
+		ownsOutput: false,
+		tags: { title: 'Not allowed' },
+	})).rejects.toThrow(/tags cannot be set by a non-owning conversion/);
+
+	await expect(Conversion.init({
+		input,
+		output: makeOutput(),
+		// @ts-expect-error Intentionally passing an invalid type
+		ownsOutput: 'yes',
+	})).rejects.toThrow(/ownsOutput/);
+});
+
+test('Non-owning execute before output.start throws a helpful error', async () => {
+	using input = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+	const conversion = await Conversion.init({ input, output, ownsOutput: false, showWarnings: false });
+	expect(conversion.isValid).toBe(true);
+
+	await expect(conversion.execute()).rejects.toThrow(/output to be started/);
+});
+
+test('Non-owning conversion composes with a user-added track', async () => {
+	using input = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		ownsOutput: false,
+		audio: { discard: true }, // The user provides their own audio track
+		showWarnings: false,
+	});
+	expect(conversion.utilizedTracks).toHaveLength(1);
+
+	const audioSource = new EncodedAudioPacketSource('aac');
+	output.addAudioTrack(audioSource);
+
+	await output.start();
+
+	await Promise.all([
+		conversion.execute(),
+		(async () => {
+			await addAacPackets(audioSource, 5);
+			audioSource.close();
+		})(),
+	]);
+
+	// The non-owning conversion must not have finalized the output
+	expect(output.state).toBe('started');
+
+	await output.finalize();
+	expect(output.state).toBe('finalized');
+
+	using result = new Input({ source: new BufferSource(output.target.buffer!), formats: ALL_FORMATS });
+	const tracks = await result.getTracks();
+	expect(tracks.map(t => t.type).sort()).toEqual(['audio', 'video']);
+
+	const videoTrack = await result.getPrimaryVideoTrack();
+	const audioTrack = await result.getPrimaryAudioTrack();
+	expect(videoTrack).not.toBeNull();
+	expect(audioTrack).not.toBeNull();
+	expect(await videoTrack!.getCodec()).toBe('avc');
+	expect(await audioTrack!.getCodec()).toBe('aac');
+	expect(await videoTrack!.computeDuration()).toBeGreaterThan(4);
+});
+
+test('Two non-owning conversions compose into one output', async () => {
+	using videoInput = makeInput();
+	using audioInput = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	const videoConversion = await Conversion.init({
+		input: videoInput,
+		output,
+		ownsOutput: false,
+		audio: { discard: true },
+		showWarnings: false,
+	});
+	const audioConversion = await Conversion.init({
+		input: audioInput,
+		output,
+		ownsOutput: false,
+		video: { discard: true },
+		showWarnings: false,
+	});
+	expect(videoConversion.utilizedTracks).toHaveLength(1);
+	expect(videoConversion.utilizedTracks[0]!.type).toBe('video');
+	expect(audioConversion.utilizedTracks).toHaveLength(1);
+	expect(audioConversion.utilizedTracks[0]!.type).toBe('audio');
+
+	await output.start();
+	await Promise.all([videoConversion.execute(), audioConversion.execute()]);
+	expect(output.state).toBe('started');
+
+	await output.finalize();
+
+	using result = new Input({ source: new BufferSource(output.target.buffer!), formats: ALL_FORMATS });
+	const tracks = await result.getTracks();
+	expect(tracks.map(t => t.type).sort()).toEqual(['audio', 'video']);
+	expect(await (await result.getPrimaryVideoTrack())!.getCodec()).toBe('avc');
+	expect(await (await result.getPrimaryAudioTrack())!.getCodec()).toBe('aac');
+});
+
+test('Non-owning conversion does not write metadata tags', async () => {
+	using input = makeInput();
+
+	// Sanity check: this input carries metadata tags that an owning conversion would copy over
+	const inputTags = await input.getMetadataTags();
+	expect(inputTags.comment).toBeDefined();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		ownsOutput: false,
+		audio: { discard: true },
+		showWarnings: false,
+	});
+
+	// The conversion must not have touched the output's metadata tags
+	expect(Object.keys(output._metadataTags)).toHaveLength(0);
+
+	const audioSource = new EncodedAudioPacketSource('aac');
+	output.addAudioTrack(audioSource);
+
+	// The user sets their own tags; these must survive
+	output.setMetadataTags({ comment: 'User-owned' });
+
+	await output.start();
+	await Promise.all([
+		conversion.execute(),
+		(async () => {
+			await addAacPackets(audioSource, 5);
+			audioSource.close();
+		})(),
+	]);
+	await output.finalize();
+
+	using result = new Input({ source: new BufferSource(output.target.buffer!), formats: ALL_FORMATS });
+	const outTags = await result.getMetadataTags();
+	// Only the user's tag is present; the input's tags were not copied
+	expect(outTags.comment).toBe('User-owned');
+});
+
+test('Canceling a non-owning conversion leaves the output usable', async () => {
+	using input = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		ownsOutput: false,
+		audio: { discard: true },
+		showWarnings: false,
+	});
+
+	const audioSource = new EncodedAudioPacketSource('aac');
+	output.addAudioTrack(audioSource);
+
+	await output.start();
+
+	const executePromise = conversion.execute();
+	void conversion.cancel();
+
+	await expect(executePromise).rejects.toBeInstanceOf(ConversionCanceledError);
+
+	// The output must not have been canceled by the non-owning conversion
+	expect(output.state).toBe('started');
+
+	// The user's own track can still finish, and the output can still be finalized
+	await addAacPackets(audioSource, 2);
+	audioSource.close();
+	await output.finalize();
+	expect(output.state).toBe('finalized');
+
+	using result = new Input({ source: new BufferSource(output.target.buffer!), formats: ALL_FORMATS });
+	const audioTrack = await result.getPrimaryAudioTrack();
+	expect(audioTrack).not.toBeNull();
+	expect(await audioTrack!.getCodec()).toBe('aac');
+});
+
+test('Track capacity is seeded from tracks already on the output', async () => {
+	using input = new Input({ source: new FilePathSource(wavPath), formats: ALL_FORMATS });
+
+	const output = new Output({ format: new WavOutputFormat(), target: new BufferTarget() });
+	// The user already occupies the single audio slot that WAVE allows
+	output.addAudioTrack(new EncodedAudioPacketSource('pcm-s16'));
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		ownsOutput: false,
+		showWarnings: false,
+	});
+
+	// The conversion's audio track has no room left, so it gets discarded and the conversion is invalid
+	expect(conversion.isValid).toBe(false);
+	expect(conversion.utilizedTracks).toHaveLength(0);
+	expect(conversion.discardedTracks).toHaveLength(1);
+	// WAVE allows only one track in total, so the total-count check fires before the per-type one
+	expect(conversion.discardedTracks[0]!.reason).toBe('max_track_count_reached');
+});

--- a/test/node/conversion.test.ts
+++ b/test/node/conversion.test.ts
@@ -290,3 +290,210 @@ test('Track capacity is seeded from tracks already on the output', async () => {
 	// WAVE allows only one track in total, so the total-count check fires before the per-type one
 	expect(conversion.discardedTracks[0]!.reason).toBe('max_track_count_reached');
 });
+
+test('onProgress on a non-owning conversion ticks monotonically up to 1', async () => {
+	using input = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		ownsOutput: false,
+		audio: { discard: true }, // The user provides their own audio track
+		showWarnings: false,
+	});
+
+	// onProgress must be assigned before execute() so the conversion knows to compute progress
+	const progressTicks: number[] = [];
+	conversion.onProgress = (progress) => {
+		progressTicks.push(progress);
+	};
+
+	const audioSource = new EncodedAudioPacketSource('aac');
+	output.addAudioTrack(audioSource);
+
+	await output.start();
+
+	await Promise.all([
+		conversion.execute(),
+		(async () => {
+			await addAacPackets(audioSource, 5);
+			audioSource.close();
+		})(),
+	]);
+	await output.finalize();
+
+	expect(progressTicks.length).toBeGreaterThan(1);
+	expect(progressTicks[0]).toBe(0);
+
+	for (let i = 1; i < progressTicks.length; i++) {
+		expect(progressTicks[i]).toBeGreaterThanOrEqual(progressTicks[i - 1]!);
+	}
+
+	expect(progressTicks[progressTicks.length - 1]).toBe(1);
+});
+
+test('Canceling one of two sibling non-owning conversions leaves the other intact', async () => {
+	using videoInput = makeInput();
+	using audioInput = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	const videoConversion = await Conversion.init({
+		input: videoInput,
+		output,
+		ownsOutput: false,
+		audio: { discard: true },
+		showWarnings: false,
+	});
+	const audioConversion = await Conversion.init({
+		input: audioInput,
+		output,
+		ownsOutput: false,
+		video: { discard: true },
+		showWarnings: false,
+	});
+
+	await output.start();
+
+	const videoExecutePromise = videoConversion.execute();
+	const audioExecutePromise = audioConversion.execute();
+	// Cancel B (the audio conversion) right as it starts pumping
+	void audioConversion.cancel();
+
+	await expect(audioExecutePromise).rejects.toBeInstanceOf(ConversionCanceledError);
+	// A (the video conversion) must complete normally, unaffected by B's cancellation
+	await expect(videoExecutePromise).resolves.toBeUndefined();
+
+	expect(output.state).toBe('started');
+
+	await output.finalize();
+	expect(output.state).toBe('finalized');
+
+	using result = new Input({ source: new BufferSource(output.target.buffer!), formats: ALL_FORMATS });
+	const videoTrack = await result.getPrimaryVideoTrack();
+	expect(videoTrack).not.toBeNull();
+	expect(await videoTrack!.getCodec()).toBe('avc');
+	expect(await videoTrack!.computeDuration()).toBeGreaterThan(4);
+});
+
+test('Track capacity is seeded across two sequential non-owning inits on the same output', async () => {
+	using inputA = new Input({ source: new FilePathSource(wavPath), formats: ALL_FORMATS });
+	using inputB = new Input({ source: new FilePathSource(wavPath), formats: ALL_FORMATS });
+
+	const output = new Output({ format: new WavOutputFormat(), target: new BufferTarget() });
+
+	// The first init adds its own audio track to the output, filling WAVE's single track slot
+	const conversionA = await Conversion.init({
+		input: inputA,
+		output,
+		ownsOutput: false,
+		showWarnings: false,
+	});
+	expect(conversionA.isValid).toBe(true);
+	expect(conversionA.utilizedTracks).toHaveLength(1);
+
+	// The second init must see that the output is already full, proving it seeds its counts from the tracks
+	// added by the first conversion (not just from tracks that existed before any conversion ran)
+	const conversionB = await Conversion.init({
+		input: inputB,
+		output,
+		ownsOutput: false,
+		showWarnings: false,
+	});
+
+	expect(conversionB.isValid).toBe(false);
+	expect(conversionB.utilizedTracks).toHaveLength(0);
+	expect(conversionB.discardedTracks).toHaveLength(1);
+	expect(conversionB.discardedTracks[0]!.reason).toBe('max_track_count_reached');
+});
+
+test('Non-owning conversion metadata is exactly what the user set, nothing more', async () => {
+	using input = makeInput(); // This input file carries its own real metadata tags
+
+	const userTags = { title: 'User Title', comment: 'User comment' };
+
+	// Baseline: an output that gets the exact same track and tags, but with no conversion attached at all. Any
+	// difference between this and the conversion-produced output would have to come from the conversion.
+	const baselineOutput = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+	const baselineSource = new EncodedAudioPacketSource('aac');
+	baselineOutput.addAudioTrack(baselineSource);
+	baselineOutput.setMetadataTags(userTags);
+	await baselineOutput.start();
+	await addAacPackets(baselineSource, 2);
+	baselineSource.close();
+	await baselineOutput.finalize();
+
+	using baselineResult = new Input({ source: new BufferSource(baselineOutput.target.buffer!), formats: ALL_FORMATS });
+	const baselineTags = await baselineResult.getMetadataTags();
+
+	// Now the same setup, but with a non-owning conversion (whose input file itself carries real metadata tags)
+	// also contributing to the output
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		ownsOutput: false,
+		audio: { discard: true },
+		showWarnings: false,
+	});
+
+	const audioSource = new EncodedAudioPacketSource('aac');
+	output.addAudioTrack(audioSource);
+	output.setMetadataTags(userTags);
+
+	await output.start();
+	await Promise.all([
+		conversion.execute(),
+		(async () => {
+			await addAacPackets(audioSource, 2);
+			audioSource.close();
+		})(),
+	]);
+	await output.finalize();
+
+	using result = new Input({ source: new BufferSource(output.target.buffer!), formats: ALL_FORMATS });
+	const outTags = await result.getMetadataTags();
+
+	// The conversion must have contributed exactly zero tags: the output's tags match the baseline byte-for-byte,
+	// even though the conversion's own input file carries real metadata tags of its own
+	expect(outTags).toEqual(baselineTags);
+});
+
+test('Canceling a non-owning conversion before execute() rejects promptly without hanging', async () => {
+	using input = makeInput();
+
+	const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		ownsOutput: false,
+		audio: { discard: true },
+		showWarnings: false,
+	});
+
+	const audioSource = new EncodedAudioPacketSource('aac');
+	output.addAudioTrack(audioSource);
+
+	await output.start();
+
+	// Cancel before execute() is ever called
+	await conversion.cancel();
+
+	// execute() must still settle promptly with a cancellation error, not hang forever
+	await expect(conversion.execute()).rejects.toBeInstanceOf(ConversionCanceledError);
+
+	// The output must remain usable; the user's own track can still finish and the output can still finalize
+	await addAacPackets(audioSource, 2);
+	audioSource.close();
+	await output.finalize();
+	expect(output.state).toBe('finalized');
+
+	using result = new Input({ source: new BufferSource(output.target.buffer!), formats: ALL_FORMATS });
+	const audioTrack = await result.getPrimaryAudioTrack();
+	expect(audioTrack).not.toBeNull();
+	expect(await audioTrack!.getCodec()).toBe('aac');
+});


### PR DESCRIPTION
## Field report: first real consumer of `ownsOutput: false`

Wired this into a browser video-dubbing tool (mux a freshly-synthesized dub track into an existing video while copying the original video track through). It's exactly the non-owning use case the flag is for, and it worked — the caller owns the `Output`, `Conversion.init({ ownsOutput: false, audio: { discard: true } })` carries the video track over, and we attach the dub as a caller-owned `AudioBufferSource`:

```ts
const conversion = await Conversion.init({ input, output, ownsOutput: false, audio: { discard: true } });
if (!conversion.isValid) throw new Error('video cannot be carried over');
const dub = new AudioBufferSource({ codec: isWebM ? 'opus' : 'aac', bitrate: 128e3 });
output.addAudioTrack(dub);
await output.start();
await Promise.all([
  conversion.execute(),
  (async () => { await dub.add(mixedBuffer); dub.close(); })(),
]);
await output.finalize();
```

Verified end-to-end: output MP4 contains both the copied H.264 video track and the AAC dub track. **The ownership model is sound and I don't think the flag needs reshaping.** But two things bit us that I'd suggest fixing before this lands, plus a couple of doc notes.

### 1. `isValid` silently changes meaning based on `ownsOutput` 🔴 design

In owning mode `isValid` means "output meets the format's minimum track count"; in non-owning mode it flips to "this conversion utilizes ≥1 track." Same property, two definitions, switched by a boolean elsewhere in the options. I had to read `conversion.ts` to be sure a discard-audio + carry-video conversion reports `true`. The name doesn't convey "contributes at least one track," and a meaning that flips by mode is easy to misread.

**Suggestion:** keep `isValid` meaning one thing, and expose the non-owning question as a distinct accessor (`utilizedTrackCount`, or `contributesTracks`). Small change, removes a real trap.

### 2. Cancel surfaces a nondeterministic, untyped error 🔴 design — this is the sharp one

The decision that `conversion.cancel()` leaves the caller's output alive is correct. But the consequence is nasty in the concurrent-pump pattern above. On abort we call `conversion.cancel()` **and** `output.cancel()` (the docs make clear you need both). Once the output is canceled, the caller's in-flight `dub.add(...)` hits `_ensureValidAdd` and throws a **plain** `Error('Output has been canceled.')` — and that beats `ConversionCanceledError` in the `Promise.all` race, because `execute()` needs more async hops to settle its own cancellation.

So the typed error the docs tell you to catch is usually *not* the one you get:

```ts
} catch (err) {
  await output.cancel().catch(() => {});
  // Needed this fallback: ConversionCanceledError alone doesn't fire on cancel,
  // because the audio pump's plain Error wins the race.
  if (signal?.aborted || err instanceof ConversionCanceledError) throw abortError();
  throw err;
}
```

Without the `signal.aborted` fallback, a user cancelling mid-mux sees a raw "Output has been canceled." error instead of a clean cancel.

**Suggestion:** give the canceled-output / canceled-source path a **typed** cancellation error (shared with, or subclassing, `ConversionCanceledError`), so a caller's `catch` is deterministic no matter which pump loses the race. This is the highest-value fix — concrete repro above.

### Doc/ergonomics notes (not redesign)

These are pre-existing `Output`/source behaviors that `ownsOutput: false` simply *stops shielding the caller from* — they don't argue against the flag, but a non-owning caller meets all of them at once:

- **Ordering is all runtime-enforced.** `addTrack → start → execute → finalize`, plus `AudioBufferSource` needs an explicit `bitrate` (compressed codecs), `tags` + non-owning throws, WebM won't take `aac`. Each is a late throw with no compile-time signal. The `execute()`-throws-if-pending guard is good; the rest is worth a **prominent "non-owning recipe" doc block** so first-timers don't discover them one throw at a time.
- **`output.cancel()` after `finalize()` warns**, so cleanup can't be a blanket `finally` — teardown has to be scoped to the catch. An idempotent/quiet cancel-after-finalize would allow the simpler pattern.

### One open question worth your call

Every non-owning caller will write the same dance: `addTrack → start → Promise.all(execute, pump) → finalize`, plus `output.cancel()` on every error path and a two-call abort. Two directions:

- **Keep it primitive** (this PR) + ship the canonical recipe and the typed-cancel fix. Trusts the caller, minimal surface.
- **Add scaffolding** — e.g. let `Conversion` accept extra caller-owned sources to pump alongside its own tracks. More convenient, but it starts re-absorbing the lifecycle that `ownsOutput: false` deliberately handed back.

My vote is **keep it primitive** — the integration proved the primitive is enough. The two things that actually cost us were the ambiguous `isValid` and the untyped cancel error, both fixable without touching the ownership model. Net: strong validation for the design as-is.