### PR TITLE
Fix WebVTT-in-MP4 output by starting the aux writer

### DIFF
--- a/src/isobmff/isobmff-muxer.ts
+++ b/src/isobmff/isobmff-muxer.ts
@@ -211,6 +211,10 @@ export class IsobmffMuxer extends Muxer {
 	async start() {
 		const release = await this.mutex.acquire();
 
+		// The auxiliary writer builds subtitle sample boxes in memory; it must be started too,
+		// else the first box write for any subtitle track asserts (started === false).
+		this.auxWriter.start();
+
 		if (!this.isCmaf) {
 			this.writer = await this.output._getRootWriter(target => (
 				this.format._options.fastStart !== undefined

--- a/src/isobmff/isobmff-muxer.ts
+++ b/src/isobmff/isobmff-muxer.ts
@@ -206,14 +206,12 @@ export class IsobmffMuxer extends Muxer {
 		this.isCmaf = format instanceof CmafOutputFormat;
 		this.minimumFragmentDuration = format._options.minimumFragmentDuration
 			?? (format instanceof CmafOutputFormat ? Infinity : 1);
+
+		this.auxWriter.start();
 	}
 
 	async start() {
 		const release = await this.mutex.acquire();
-
-		// The auxiliary writer builds subtitle sample boxes in memory; it must be started too,
-		// else the first box write for any subtitle track asserts (started === false).
-		this.auxWriter.start();
 
 		if (!this.isCmaf) {
 			this.writer = await this.output._getRootWriter(target => (

--- a/test/node/webvtt.test.ts
+++ b/test/node/webvtt.test.ts
@@ -1,0 +1,57 @@
+import { test } from 'vitest';
+import { Output } from '../../src/output.js';
+import { MkvOutputFormat, Mp4OutputFormat } from '../../src/output-format.js';
+import { BufferTarget } from '../../src/target.js';
+import { TextSubtitleSource } from '../../src/media-source.js';
+
+test('ISOBMFF muxing', async () => {
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+
+	const source = new TextSubtitleSource('webvtt');
+	output.addSubtitleTrack(source);
+
+	await output.start();
+
+	await source.add(`WEBVTT
+
+00:00.000 --> 00:00.900
+Hildy!
+
+00:01.000 --> 00:01.400
+How are you?
+
+00:01.500 --> 00:02.900
+Tell me, is the lord of the universe in?
+`);
+
+	await output.finalize();
+});
+
+test('Matroska muxing', async () => {
+	const output = new Output({
+		format: new MkvOutputFormat(),
+		target: new BufferTarget(),
+	});
+
+	const source = new TextSubtitleSource('webvtt');
+	output.addSubtitleTrack(source);
+
+	await output.start();
+
+	await source.add(`WEBVTT
+
+00:00.000 --> 00:00.900
+Hildy!
+
+00:01.000 --> 00:01.400
+How are you?
+
+00:01.500 --> 00:02.900
+Tell me, is the lord of the universe in?
+`);
+
+	await output.finalize();
+});


### PR DESCRIPTION
### Problem

`Mp4OutputFormat` / `CmafOutputFormat` list `webvtt` in their supported subtitle codecs, and the ISOBMFF muxer maps it to the `wvtt` sample entry, so muxing a WebVTT track into MP4/MOV looks supported. In practice it fails: `IsobmffMuxer.start()` starts the main writer but never calls `this.auxWriter.start()`. The aux writer is where subtitle sample boxes are assembled, so the first subtitle sample write trips its `started === false` assertion and muxing throws.

### Fix

Start the auxiliary writer alongside the main writer in `start()`. One line; no API or format change. Video/audio-only output is unaffected (the aux writer was already constructed, just never started).

### Repro

Create an `Output` with `Mp4OutputFormat`, add a `TextSubtitleSource('webvtt')`, add a cue, and `finalize()` — it asserts before this change and produces a valid `wvtt` track after.

Found while working on subtitle muxing; the fix is independent of any new codec.