### PR TITLE
Give Matroska subtitle cues a BlockDuration

### DIFF
--- a/src/matroska/matroska-muxer.ts
+++ b/src/matroska/matroska-muxer.ts
@@ -1168,7 +1168,12 @@ export class MatroskaMuxer extends Muxer {
 
 		const msDuration = Math.round(1000 * chunk.duration);
 
-		if (!chunk.additions) {
+		// Subtitle cues need an explicit BlockDuration (a SimpleBlock has none), otherwise players
+		// like VLC/libass don't know how long to show the cue and render nothing. So a subtitle with
+		// a duration must go into a BlockGroup even when it has no additions.
+		const needsBlockGroup = !!chunk.additions || (trackData.type === 'subtitle' && msDuration > 0);
+
+		if (!needsBlockGroup) {
 			// No additions, we can write out a SimpleBlock
 			view.setUint8(3, Number(chunk.type === 'key') << 7); // Flags (keyframe flag only present for SimpleBlock)
 


### PR DESCRIPTION
### Problem

The Matroska muxer writes subtitle cues as `SimpleBlock`s. A `SimpleBlock` encodes the cue's start time but has no duration field, so the player is never told how long to display the cue. For text subtitles (`S_TEXT/WEBVTT`) this means players like VLC and libass-based renderers show nothing, or flash the cue for a single frame, because the cue's end time is lost.

### Fix

A subtitle chunk that has a positive duration is now routed through a `BlockGroup` so its `BlockDuration` is written, reusing the existing BlockGroup path already taken when a block has additions:

```ts
const needsBlockGroup = !!chunk.additions || (trackData.type === 'subtitle' && msDuration > 0);
```

Non-subtitle tracks and zero-duration cues are unchanged and keep using `SimpleBlock`s.

### Repro

Mux a WebVTT cue with a known duration into an `.mkv`, then play it: without this change the cue has no visible end; with it the cue shows for its full duration and the written block carries a `BlockDuration` element.

Found while working on subtitle muxing; the fix applies to the existing WebVTT path.