### PR TITLE
Add S_TEXT/ASS subtitle muxing to the Matroska muxer

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -92,6 +92,7 @@ export const AUDIO_CODECS = [
  */
 export const SUBTITLE_CODECS = [
 	'webvtt',
+	'ass',
 ] as const; // TODO add the rest
 
 /**

--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -688,7 +688,8 @@ export const stsd = (trackData: IsobmffTrackData) => {
 		);
 	} else if (trackData.type === 'subtitle') {
 		sampleDescription = subtitleSampleDescription(
-			SUBTITLE_CODEC_TO_BOX_NAME[trackData.track.source._codec],
+			// Non-null: only ISOBMFF-supported subtitle codecs reach the muxer (validated on add).
+			SUBTITLE_CODEC_TO_BOX_NAME[trackData.track.source._codec]!,
 			trackData,
 		);
 	}
@@ -1110,7 +1111,8 @@ export const subtitleSampleDescription = (
 	Array(6).fill(0), // Reserved
 	u16(1), // Data reference index
 ], [
-	SUBTITLE_CODEC_TO_CONFIGURATION_BOX[trackData.track.source._codec](trackData),
+	// Non-null: only ISOBMFF-supported subtitle codecs reach the muxer (validated on add).
+	SUBTITLE_CODEC_TO_CONFIGURATION_BOX[trackData.track.source._codec]!(trackData),
 ]);
 
 export const vttC = (trackData: IsobmffSubtitleTrackData) => box('vttC', [
@@ -1882,14 +1884,16 @@ const audioCodecToConfigurationBox = (codec: AudioCodec, isQuickTime: boolean) =
 	return null;
 };
 
-const SUBTITLE_CODEC_TO_BOX_NAME: Record<SubtitleCodec, string> = {
+// ISOBMFF only supports the subtitle codecs listed here; others (e.g. 'ass', which is
+// Matroska-only) are rejected at track-add time and never reach these maps.
+const SUBTITLE_CODEC_TO_BOX_NAME: Partial<Record<SubtitleCodec, string>> = {
 	webvtt: 'wvtt',
 };
 
-const SUBTITLE_CODEC_TO_CONFIGURATION_BOX: Record<
+const SUBTITLE_CODEC_TO_CONFIGURATION_BOX: Partial<Record<
 	SubtitleCodec,
 	(trackData: IsobmffSubtitleTrackData) => Box | null
-> = {
+>> = {
 	webvtt: vttC,
 };
 

--- a/src/isobmff/isobmff-muxer.ts
+++ b/src/isobmff/isobmff-muxer.ts
@@ -328,10 +328,11 @@ export class IsobmffMuxer extends Muxer {
 			} else if (trackData.type === 'audio') {
 				return trackData.info.decoderConfig.codec;
 			} else {
-				const map: Record<SubtitleCodec, string> = {
+				// Only ISOBMFF-supported subtitle codecs reach the muxer (validated on add).
+				const map: Partial<Record<SubtitleCodec, string>> = {
 					webvtt: 'wvtt',
 				};
-				return map[trackData.track.source._codec];
+				return map[trackData.track.source._codec]!;
 			}
 		});
 

--- a/src/matroska/ebml.ts
+++ b/src/matroska/ebml.ts
@@ -761,6 +761,7 @@ export const CODEC_STRING_MAP: Partial<Record<MediaCodec, string>> = {
 	'pcm-f64': 'A_PCM/FLOAT/IEEE',
 
 	'webvtt': 'S_TEXT/WEBVTT',
+	'ass': 'S_TEXT/ASS',
 };
 
 export function assertDefinedSize(size: number | undefined): asserts size is number {

--- a/src/matroska/matroska-muxer.ts
+++ b/src/matroska/matroska-muxer.ts
@@ -711,6 +711,7 @@ export class MatroskaMuxer extends Muxer {
 			} else {
 				const map: Record<SubtitleCodec, string> = {
 					webvtt: 'wvtt',
+					ass: 'ass',
 				};
 				return map[trackData.track.source._codec];
 			}

--- a/src/output-format.ts
+++ b/src/output-format.ts
@@ -320,7 +320,7 @@ export class Mp4OutputFormat extends IsobmffOutputFormat {
 			'pcm-f64',
 			'pcm-f64be',
 
-			...SUBTITLE_CODECS,
+			'webvtt', // ISOBMFF (MP4/MOV) subtitles: WebVTT only; S_TEXT/ASS is Matroska-specific
 		];
 	}
 
@@ -389,7 +389,7 @@ export class CmafOutputFormat extends IsobmffOutputFormat {
 			'pcm-f64',
 			'pcm-f64be',
 
-			...SUBTITLE_CODECS,
+			'webvtt', // ISOBMFF (MP4/MOV) subtitles: WebVTT only; S_TEXT/ASS is Matroska-specific
 		];
 	}
 }
@@ -597,7 +597,7 @@ export class WebMOutputFormat extends MkvOutputFormat {
 		return [
 			...VIDEO_CODECS.filter(codec => ['vp8', 'vp9', 'av1'].includes(codec)),
 			...AUDIO_CODECS.filter(codec => ['opus', 'vorbis'].includes(codec)),
-			...SUBTITLE_CODECS,
+			'webvtt', // WebM subtitles: WebVTT only
 		];
 	}
 

--- a/src/subtitles.ts
+++ b/src/subtitles.ts
@@ -24,8 +24,15 @@ export type SubtitleMetadata = {
 };
 
 type SubtitleParserOptions = {
-	codec: 'webvtt';
+	codec: 'webvtt' | 'ass';
 	output: (cue: SubtitleCue, metadata: SubtitleMetadata) => unknown;
+};
+
+// ASS/SSA timestamp "H:MM:SS.cc" (centiseconds) -> milliseconds.
+const parseAssTimestamp = (s: string): number => {
+	const m = /(\d+):(\d{2}):(\d{2})\.(\d{2})/.exec(s.trim());
+	if (!m) return 0;
+	return Number(m[1]) * 3600000 + Number(m[2]) * 60000 + Number(m[3]) * 1000 + Number(m[4]) * 10;
 };
 
 const cueBlockHeaderRegex = /(?:(.+?)\n)?((?:\d{2}:)?\d{2}:\d{2}.\d{3})\s+-->\s+((?:\d{2}:)?\d{2}:\d{2}.\d{3})/g;
@@ -36,12 +43,19 @@ export class SubtitleParser {
 	private options: SubtitleParserOptions;
 	private preambleText: string | null = null;
 	private preambleEmitted = false;
+	private assReadOrder = 0;
+	private assConfigEmitted = false;
 
 	constructor(options: SubtitleParserOptions) {
 		this.options = options;
 	}
 
 	parse(text: string) {
+		if (this.options.codec === 'ass') {
+			this.parseAss(text);
+			return;
+		}
+
 		text = text.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
 
 		cueBlockHeaderRegex.lastIndex = 0;
@@ -103,6 +117,80 @@ export class SubtitleParser {
 			}
 
 			this.options.output(cue, meta);
+		}
+	}
+
+	// Parse an ASS/SSA document: the header (up to and including the [Events] Format line)
+	// becomes the CodecPrivate; each Dialogue line becomes a cue whose text is the S_TEXT/ASS
+	// block payload "ReadOrder,Layer,Style,Name,MarginL,MarginR,MarginV,Effect,Text".
+	private parseAss(text: string) {
+		const lines = text.replaceAll('\r\n', '\n').replaceAll('\r', '\n').split('\n');
+		let formatIdx = -1;
+		let inEvents = false;
+		for (let i = 0; i < lines.length; i++) {
+			const trimmed = (lines[i] ?? '').trim();
+			if (/^\[events\]/i.test(trimmed)) {
+				inEvents = true;
+			} else if (inEvents && /^format:/i.test(trimmed)) {
+				formatIdx = i;
+				break;
+			}
+		}
+		if (formatIdx === -1) throw new Error('ASS document has no [Events] Format line.');
+
+		const header = lines.slice(0, formatIdx + 1).join('\n');
+		const fmt = (lines[formatIdx] ?? '').replace(/^\s*format:\s*/i, '').split(',').map(s => s.trim().toLowerCase());
+		const col = (name: string) => fmt.indexOf(name);
+		const iStart = col('start');
+		const iEnd = col('end');
+		const iText = col('text');
+		const cols = {
+			layer: col('layer'),
+			style: col('style'),
+			name: col('name'),
+			ml: col('marginl'),
+			mr: col('marginr'),
+			mv: col('marginv'),
+			effect: col('effect'),
+		};
+
+		for (let i = formatIdx + 1; i < lines.length; i++) {
+			const m = /^\s*dialogue:\s*(.*)$/i.exec(lines[i] ?? '');
+			if (!m) {
+				continue;
+			}
+
+			const bits = (m[1] ?? '').split(',');
+			// The Text column is last and may itself contain commas, so it takes every remaining field.
+			const field = (idx: number): string => {
+				if (idx < 0) return '';
+				return idx === iText ? bits.slice(iText).join(',') : (bits[idx] ?? '');
+			};
+			const start = parseAssTimestamp(field(iStart));
+			const end = parseAssTimestamp(field(iEnd));
+			const payload = [
+				this.assReadOrder,
+				field(cols.layer) || '0',
+				field(cols.style),
+				field(cols.name),
+				field(cols.ml) || '0',
+				field(cols.mr) || '0',
+				field(cols.mv) || '0',
+				field(cols.effect),
+				field(iText),
+			].join(',');
+
+			const meta: SubtitleMetadata = {};
+			if (!this.assConfigEmitted) {
+				meta.config = { description: header };
+				this.assConfigEmitted = true;
+			}
+
+			this.options.output(
+				{ timestamp: start / 1000, duration: Math.max(0, end - start) / 1000, text: payload },
+				meta,
+			);
+			this.assReadOrder++;
 		}
 	}
 }

--- a/test/node/matroska-ass-subtitles.test.ts
+++ b/test/node/matroska-ass-subtitles.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'vitest';
+import { Output } from '../../src/output.js';
+import { BufferTarget } from '../../src/target.js';
+import { MkvOutputFormat, Mp4OutputFormat, WebMOutputFormat } from '../../src/output-format.js';
+import { TextSubtitleSource } from '../../src/media-source.js';
+
+const ASS = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, BackColour, Bold, Alignment
+Style: Default,Arial,20,&H00FFFFFF,&H00000000,0,2
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:03.50,Default,,0,0,0,,Hello world
+Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,Second line
+`;
+
+// The subtitle codec strings and payloads are ASCII, so decode the raw container as latin1
+// and look for them. (mediabunny's Input demuxes only audio/video, so we assert on bytes.)
+const decoder = new TextDecoder('latin1');
+const contains = (buffer: ArrayBuffer, needle: string) => decoder.decode(buffer).includes(needle);
+
+test('Matroska muxer writes an S_TEXT/ASS subtitle track', async () => {
+	const output = new Output({
+		format: new MkvOutputFormat(),
+		target: new BufferTarget(),
+	});
+
+	const source = new TextSubtitleSource('ass');
+	output.addSubtitleTrack(source);
+
+	await output.start();
+	await source.add(ASS);
+	await output.finalize();
+
+	const buffer = output.target.buffer!;
+	expect(buffer).not.toBeNull();
+	expect(buffer.byteLength).toBeGreaterThan(0);
+
+	// The Matroska CodecID for ASS.
+	expect(contains(buffer, 'S_TEXT/ASS')).toBe(true);
+
+	// The header up to and including the [Events] Format line is stored as CodecPrivate.
+	expect(contains(buffer, '[Script Info]')).toBe(true);
+	const eventsFormat = 'Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text';
+	expect(contains(buffer, eventsFormat)).toBe(true);
+
+	// Each Dialogue becomes a block whose text is the S_TEXT/ASS payload, reordered to
+	// "ReadOrder,Layer,Style,Name,MarginL,MarginR,MarginV,Effect,Text" with an incrementing ReadOrder.
+	expect(contains(buffer, '0,0,Default,,0,0,0,,Hello world')).toBe(true);
+	expect(contains(buffer, '1,0,Default,,0,0,0,,Second line')).toBe(true);
+});
+
+test('WebM and MP4 reject the ASS subtitle codec, Matroska accepts it', () => {
+	const mkv = new Output({ format: new MkvOutputFormat(), target: new BufferTarget() });
+	expect(() => mkv.addSubtitleTrack(new TextSubtitleSource('ass'))).not.toThrow();
+
+	const webm = new Output({ format: new WebMOutputFormat(), target: new BufferTarget() });
+	expect(() => webm.addSubtitleTrack(new TextSubtitleSource('ass'))).toThrow(/cannot be contained/);
+
+	const mp4 = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+	expect(() => mp4.addSubtitleTrack(new TextSubtitleSource('ass'))).toThrow(/cannot be contained/);
+});


### PR DESCRIPTION
### What

Adds ASS/SSA (`S_TEXT/ASS`) as a second subtitle codec for Matroska output, alongside the existing WebVTT support. This lets styled ASS subtitle tracks be muxed into `.mkv`, which is the standard container for them (ffmpeg/VLC use `S_TEXT/ASS` with the ASS header in `CodecPrivate`). Opening it as a proposal, happy to adjust the shape to your preferences.

### How

- Add `'ass'` to `SUBTITLE_CODECS` and map it to the `S_TEXT/ASS` Matroska CodecID.
- `SubtitleParser` learns to parse an ASS document: the header up to and including the `[Events]` `Format:` line becomes the track's `CodecPrivate`, and each `Dialogue:` line becomes a cue whose text is the `S_TEXT/ASS` block payload `ReadOrder,Layer,Style,Name,MarginL,MarginR,MarginV,Effect,Text` with an incrementing `ReadOrder`. This reuses the exact `metadata.config` / `CodecPrivate` path already used for WebVTT, so no muxer plumbing changes.
- ASS is **Matroska-only**. ISOBMFF (MP4/MOV) and WebM keep advertising WebVTT only, so a `TextSubtitleSource('ass')` added to those formats is rejected at `addSubtitleTrack` time by the existing codec validation. The ISOBMFF subtitle codec maps therefore become `Partial<Record<...>>` and simply omit `'ass'` rather than carrying a dummy entry.

### Design notes / questions

- I widened `SubtitleParserOptions.codec` to `'webvtt' | 'ass'` (an explicit union rather than `SubtitleCodec`) so that adding a future codec to `SUBTITLE_CODECS` without a matching parser branch is a compile error. Let me know if you'd prefer a different split (e.g. a per-codec parser strategy).
- Comment `Dialogue`-only: ASS `Comment:` lines are dropped, matching the ffmpeg mux convention (only rendered events carry a `ReadOrder`).

### Tests

`test/node/matroska-ass-subtitles.test.ts` covers the written `S_TEXT/ASS` track (CodecID, the `CodecPrivate` header, and the reordered block payloads with incrementing `ReadOrder`) and the per-format codec acceptance (Matroska accepts, WebM/MP4 reject). Full node suite passes locally.

### Related

Complements two small subtitle bug-fix PRs (independent of this one, but relevant to actually playing back the result): #441 (WebVTT-in-MP4 aux writer) and #442 (Matroska subtitle `BlockDuration`, which text subtitles including these ASS cues need to display for their full duration).