### PR TITLE
Add encoder-native video resizing

### DIFF
--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -189,6 +189,12 @@ export type ConversionVideoOptions = {
 	 */
 	fit?: 'fill' | 'contain' | 'cover';
 	/**
+	 * How resizing is performed. `'canvas'` (default) resizes decoded frames before encoding and supports all fitting
+	 * modes. `'encoder'` passes frames at their original resolution and lets the encoder scale them, which may improve
+	 * quality or performance. Encoder resizing only supports the `'fill'` fitting mode.
+	 */
+	resizeMode?: 'canvas' | 'encoder';
+	/**
 	 * The angle in degrees to rotate the input video by, clockwise. Rotation is applied before cropping and resizing.
 	 * This rotation is _in addition to_ the natural rotation of the input video as specified in input file's metadata.
 	 */
@@ -378,6 +384,12 @@ const validateVideoOptions = (videoOptions: ConversionVideoOptions) => {
 	}
 	if (videoOptions?.fit !== undefined && !['fill', 'contain', 'cover'].includes(videoOptions.fit)) {
 		throw new TypeError('options.video.fit, when provided, must be one of \'fill\', \'contain\', or \'cover\'.');
+	}
+	if (videoOptions?.resizeMode !== undefined && !['canvas', 'encoder'].includes(videoOptions.resizeMode)) {
+		throw new TypeError('options.video.resizeMode, when provided, must be one of \'canvas\' or \'encoder\'.');
+	}
+	if (videoOptions?.resizeMode === 'encoder' && videoOptions.fit !== undefined && videoOptions.fit !== 'fill') {
+		throw new TypeError('options.video.fit must be \'fill\' when options.video.resizeMode is \'encoder\'.');
 	}
 	if (
 		videoOptions?.width !== undefined
@@ -1469,9 +1481,21 @@ export class Conversion {
 			};
 			assert(encodingConfig.transform);
 
-			let needsRerender = width !== originalWidth
-				|| height !== originalHeight
-				|| (totalRotation !== 0 && (!canUseRotationMetadata || trackOptions.process !== undefined))
+			const needsResize = width !== originalWidth || height !== originalHeight;
+			if (needsResize) {
+				encodingConfig.transform.resizeMode = trackOptions.resizeMode;
+				if (trackOptions.resizeMode === 'encoder') {
+					encodingConfig.transform.width = width;
+					encodingConfig.transform.height = height;
+					encodingConfig.transform.fit = 'fill';
+				}
+			}
+			let needsRerender = (needsResize && trackOptions.resizeMode !== 'encoder')
+				|| (totalRotation !== 0 && (
+					!canUseRotationMetadata
+					|| trackOptions.process !== undefined
+					|| trackOptions.resizeMode === 'encoder'
+				))
 				|| !!crop
 				// Don't expect encoders to reliably handle non-square pixels:
 				|| squarePixelWidth !== await track.getCodedWidth()
@@ -1535,6 +1559,9 @@ export class Conversion {
 				encodingConfig.transform.rotate = normalizeRotation(totalRotation - innateRotation);
 				encodingConfig.transform.crop = crop;
 				encodingConfig.transform.alpha = alpha;
+				if (trackOptions.resizeMode === 'encoder') {
+					encodingConfig.transform.force = true;
+				}
 			}
 
 			// We need to do this because `process` can emit new timestamps

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -191,7 +191,7 @@ export type ConversionVideoOptions = {
 	/**
 	 * How resizing is performed. `'canvas'` (default) resizes decoded frames before encoding and supports all fitting
 	 * modes. `'encoder'` passes frames at their original resolution and lets the encoder scale them, which may improve
-	 * quality or performance. Encoder resizing only supports the `'fill'` fitting mode.
+	 * quality or performance. Encoder resizing only supports the `'fill'` and `'cover'` fitting modes.
 	 */
 	resizeMode?: 'canvas' | 'encoder';
 	/**
@@ -388,8 +388,14 @@ const validateVideoOptions = (videoOptions: ConversionVideoOptions) => {
 	if (videoOptions?.resizeMode !== undefined && !['canvas', 'encoder'].includes(videoOptions.resizeMode)) {
 		throw new TypeError('options.video.resizeMode, when provided, must be one of \'canvas\' or \'encoder\'.');
 	}
-	if (videoOptions?.resizeMode === 'encoder' && videoOptions.fit !== undefined && videoOptions.fit !== 'fill') {
-		throw new TypeError('options.video.fit must be \'fill\' when options.video.resizeMode is \'encoder\'.');
+	if (
+		videoOptions?.resizeMode === 'encoder'
+		&& videoOptions.fit !== undefined
+		&& !['fill', 'cover'].includes(videoOptions.fit)
+	) {
+		throw new TypeError(
+			'options.video.fit must be \'fill\' or \'cover\' when options.video.resizeMode is \'encoder\'.',
+		);
 	}
 	if (
 		videoOptions?.width !== undefined
@@ -1482,12 +1488,13 @@ export class Conversion {
 			assert(encodingConfig.transform);
 
 			const needsResize = width !== originalWidth || height !== originalHeight;
-			if (needsResize) {
+			const needsEncoderTransform = trackOptions.resizeMode === 'encoder' && (needsResize || !!crop);
+			if (needsResize || needsEncoderTransform) {
 				encodingConfig.transform.resizeMode = trackOptions.resizeMode;
 				if (trackOptions.resizeMode === 'encoder') {
 					encodingConfig.transform.width = width;
 					encodingConfig.transform.height = height;
-					encodingConfig.transform.fit = 'fill';
+					encodingConfig.transform.fit = trackOptions.fit ?? 'fill';
 				}
 			}
 			let needsRerender = (needsResize && trackOptions.resizeMode !== 'encoder')
@@ -1496,7 +1503,7 @@ export class Conversion {
 					|| trackOptions.process !== undefined
 					|| trackOptions.resizeMode === 'encoder'
 				))
-				|| !!crop
+				|| (!!crop && trackOptions.resizeMode !== 'encoder')
 				// Don't expect encoders to reliably handle non-square pixels:
 				|| squarePixelWidth !== await track.getCodedWidth()
 				|| squarePixelHeight !== await track.getCodedHeight();

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -87,6 +87,13 @@ export type VideoEncodingConfig = {
  */
 export type VideoTransformOptions = {
 	/**
+	 * How resizing is performed. `'canvas'` (default) resizes frames before encoding and supports all fitting modes.
+	 * `'encoder'` passes frames to the encoder at their original resolution and lets the encoder scale them to the
+	 * configured width and height. Encoder resizing may be faster or higher-quality, but only supports the `'fill'`
+	 * fitting mode and requires both width and height to be set.
+	 */
+	resizeMode?: 'canvas' | 'encoder';
+	/**
 	 * The width in pixels to resize the frames to. If height is not set, it will be deduced
 	 * automatically based on aspect ratio.
 	 */
@@ -186,6 +193,14 @@ export const validateVideoEncodingConfig = (config: VideoEncodingConfig) => {
 			throw new TypeError('config.transform, when provided, must be an object.');
 		}
 		if (
+			config.transform.resizeMode !== undefined
+			&& !['canvas', 'encoder'].includes(config.transform.resizeMode)
+		) {
+			throw new TypeError(
+				'config.transform.resizeMode, when provided, must be one of "canvas" or "encoder".',
+			);
+		}
+		if (
 			config.transform.width !== undefined
 			&& (!Number.isInteger(config.transform.width) || config.transform.width <= 0)
 		) {
@@ -199,6 +214,24 @@ export const validateVideoEncodingConfig = (config: VideoEncodingConfig) => {
 		}
 		if (config.transform.fit !== undefined && !['fill', 'contain', 'cover'].includes(config.transform.fit)) {
 			throw new TypeError('config.transform.fit, when provided, must be one of "fill", "contain", or "cover".');
+		}
+		if (
+			config.transform.resizeMode === 'encoder'
+			&& (config.transform.width === undefined || config.transform.height === undefined)
+		) {
+			throw new TypeError(
+				'config.transform.width and config.transform.height must both be provided when'
+				+ ' config.transform.resizeMode is "encoder".',
+			);
+		}
+		if (
+			config.transform.resizeMode === 'encoder'
+			&& config.transform.fit !== undefined
+			&& config.transform.fit !== 'fill'
+		) {
+			throw new TypeError(
+				'config.transform.fit must be "fill" when config.transform.resizeMode is "encoder".',
+			);
 		}
 		if (
 			config.transform.width !== undefined

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -90,7 +90,7 @@ export type VideoTransformOptions = {
 	 * How resizing is performed. `'canvas'` (default) resizes frames before encoding and supports all fitting modes.
 	 * `'encoder'` passes frames to the encoder at their original resolution and lets the encoder scale them to the
 	 * configured width and height. Encoder resizing may be faster or higher-quality, but only supports the `'fill'`
-	 * fitting mode and requires both width and height to be set.
+	 * and `'cover'` fitting modes and requires both width and height to be set.
 	 */
 	resizeMode?: 'canvas' | 'encoder';
 	/**
@@ -227,10 +227,10 @@ export const validateVideoEncodingConfig = (config: VideoEncodingConfig) => {
 		if (
 			config.transform.resizeMode === 'encoder'
 			&& config.transform.fit !== undefined
-			&& config.transform.fit !== 'fill'
+			&& !['fill', 'cover'].includes(config.transform.fit)
 		) {
 			throw new TypeError(
-				'config.transform.fit must be "fill" when config.transform.resizeMode is "encoder".',
+				'config.transform.fit must be "fill" or "cover" when config.transform.resizeMode is "encoder".',
 			);
 		}
 		if (

--- a/src/media-source.ts
+++ b/src/media-source.ts
@@ -296,6 +296,7 @@ class VideoEncoderWrapper {
 
 			const config = this.encodingConfig;
 			const sizeChangeBehavior = config.sizeChangeBehavior ?? 'deny';
+			const useEncoderResize = config.transform?.resizeMode === 'encoder';
 			let isSizeChange = false;
 
 			// Ensure video sample size remains constant or handle the change
@@ -317,16 +318,20 @@ class VideoEncoderWrapper {
 			}
 
 			// Determine if we need to apply transformations via canvas
-			const hasTransformConfig = config.transform?.width !== undefined
+			const hasResizeTransform = !useEncoderResize && (
+				config.transform?.width !== undefined
 				|| config.transform?.height !== undefined
+			);
+			const hasTransformConfig = hasResizeTransform
 				|| config.transform?.rotate !== undefined
 				|| config.transform?.crop !== undefined
 				|| config.transform?.force === true;
-			const needsTransform = hasTransformConfig || (isSizeChange && sizeChangeBehavior !== 'passThrough');
+			const needsTransform = hasTransformConfig
+				|| (isSizeChange && sizeChangeBehavior !== 'passThrough' && !useEncoderResize);
 
 			if (needsTransform) {
-				let targetWidth = config.transform?.width;
-				let targetHeight = config.transform?.height;
+				let targetWidth = useEncoderResize ? undefined : config.transform?.width;
+				let targetHeight = useEncoderResize ? undefined : config.transform?.height;
 				let appliedFit: 'fill' | 'contain' | 'cover' = config.transform?.fit ?? 'fill';
 
 				// If the size changed and behavior is fill/contain/cover, lock to the original output dimensions
@@ -352,8 +357,12 @@ class VideoEncoderWrapper {
 
 				// Save the output dimensions of the first frame
 				if (this.outputWidth === null || this.outputHeight === null) {
-					this.outputWidth = transformed.displayWidth;
-					this.outputHeight = transformed.displayHeight;
+					this.outputWidth = useEncoderResize
+						? config.transform!.width!
+						: transformed.displayWidth;
+					this.outputHeight = useEncoderResize
+						? config.transform!.height!
+						: transformed.displayHeight;
 				}
 
 				if (shouldClose) {
@@ -365,8 +374,12 @@ class VideoEncoderWrapper {
 			} else {
 				// If no canvas is needed, we still need to record the output dimensions for the first frame
 				if (this.outputWidth === null || this.outputHeight === null) {
-					this.outputWidth = videoSample.codedWidth;
-					this.outputHeight = videoSample.codedHeight;
+					this.outputWidth = useEncoderResize
+						? config.transform!.width!
+						: videoSample.codedWidth;
+					this.outputHeight = useEncoderResize
+						? config.transform!.height!
+						: videoSample.codedHeight;
 				}
 			}
 
@@ -655,10 +668,18 @@ class VideoEncoderWrapper {
 			const candidates = buildVideoEncoderConfigs({
 				...this.encodingConfig,
 				quality,
-				width: videoSample.codedWidth,
-				height: videoSample.codedHeight,
-				squarePixelWidth: videoSample.squarePixelWidth,
-				squarePixelHeight: videoSample.squarePixelHeight,
+				width: this.encodingConfig.transform?.resizeMode === 'encoder'
+					? this.encodingConfig.transform.width!
+					: videoSample.codedWidth,
+				height: this.encodingConfig.transform?.resizeMode === 'encoder'
+					? this.encodingConfig.transform.height!
+					: videoSample.codedHeight,
+				squarePixelWidth: this.encodingConfig.transform?.resizeMode === 'encoder'
+					? this.encodingConfig.transform.width!
+					: videoSample.squarePixelWidth,
+				squarePixelHeight: this.encodingConfig.transform?.resizeMode === 'encoder'
+					? this.encodingConfig.transform.height!
+					: videoSample.squarePixelHeight,
 				framerate: this.source._connectedTrack?.metadata.frameRate,
 			});
 

--- a/src/media-source.ts
+++ b/src/media-source.ts
@@ -324,7 +324,7 @@ class VideoEncoderWrapper {
 			);
 			const hasTransformConfig = hasResizeTransform
 				|| config.transform?.rotate !== undefined
-				|| config.transform?.crop !== undefined
+				|| (!useEncoderResize && config.transform?.crop !== undefined)
 				|| config.transform?.force === true;
 			const needsTransform = hasTransformConfig
 				|| (isSizeChange && sizeChangeBehavior !== 'passThrough' && !useEncoderResize);
@@ -428,6 +428,43 @@ class VideoEncoderWrapper {
 	/**
 	 * Runs the process function (if any) and encodes the resulting samples.
 	 */
+	private getNativeCrop(videoSample: VideoSample) {
+		const transform = this.encodingConfig.transform;
+		if (
+			transform?.resizeMode !== 'encoder'
+			|| transform.rotate !== undefined
+			|| transform.force === true
+		) {
+			return null;
+		}
+
+		let left = transform.crop?.left ?? 0;
+		let top = transform.crop?.top ?? 0;
+		let width = transform.crop?.width ?? videoSample.codedWidth;
+		let height = transform.crop?.height ?? videoSample.codedHeight;
+
+		if (transform.fit === 'cover') {
+			const targetAspectRatio = transform.width! / transform.height!;
+			const sourceAspectRatio = width / height;
+
+			if (sourceAspectRatio > targetAspectRatio) {
+				const newWidth = Math.round(height * targetAspectRatio);
+				left += Math.round((width - newWidth) / 2);
+				width = newWidth;
+			} else if (sourceAspectRatio < targetAspectRatio) {
+				const newHeight = Math.round(width / targetAspectRatio);
+				top += Math.round((height - newHeight) / 2);
+				height = newHeight;
+			}
+		}
+
+		if (left === 0 && top === 0 && width === videoSample.codedWidth && height === videoSample.codedHeight) {
+			return null;
+		}
+
+		return { left, top, width, height };
+	}
+
 	private async processAndEncode(
 		videoSample: VideoSample,
 		encodeOptions?: VideoEncoderEncodeOptions,
@@ -556,7 +593,35 @@ class VideoEncoderWrapper {
 				} else {
 					assert(this.encoder);
 
-					const videoFrame = sampleToEncode.toVideoFrame();
+					let videoFrame = sampleToEncode.toVideoFrame();
+					const nativeCrop = this.getNativeCrop(sampleToEncode);
+					if (nativeCrop) {
+						const rect = {
+							x: (videoFrame.visibleRect?.x ?? 0) + nativeCrop.left,
+							y: (videoFrame.visibleRect?.y ?? 0) + nativeCrop.top,
+							width: nativeCrop.width,
+							height: nativeCrop.height,
+						};
+						let croppedFrame: VideoFrame | undefined;
+						try {
+							assert(videoFrame.format);
+							const data = new ArrayBuffer(videoFrame.allocationSize({ rect }));
+							const layout = await videoFrame.copyTo(data, { rect });
+							croppedFrame = new VideoFrame(data, {
+								format: videoFrame.format,
+								codedWidth: nativeCrop.width,
+								codedHeight: nativeCrop.height,
+								layout,
+								timestamp: videoFrame.timestamp,
+								duration: videoFrame.duration ?? undefined,
+								colorSpace: videoFrame.colorSpace,
+							});
+						} finally {
+							videoFrame.close();
+						}
+						assert(croppedFrame);
+						videoFrame = croppedFrame;
+					}
 
 					const preciseTimingIndex = binarySearchLessOrEqual(
 						this.preciseTimings,
@@ -691,10 +756,12 @@ class VideoEncoderWrapper {
 				const candidateConfig = candidate.config;
 				this.encodingConfig.onEncoderConfig?.(candidateConfig);
 
-				MatchingCustomEncoder = customVideoEncoders.find(x => x.supports(
-					this.encodingConfig.codec,
-					candidateConfig,
-				));
+				MatchingCustomEncoder = this.encodingConfig.transform?.resizeMode === 'encoder'
+					? undefined
+					: customVideoEncoders.find(x => x.supports(
+							this.encodingConfig.codec,
+							candidateConfig,
+						));
 				if (MatchingCustomEncoder) {
 					selected = candidate;
 					break;

--- a/test/browser/conversion.test.ts
+++ b/test/browser/conversion.test.ts
@@ -111,6 +111,48 @@ test('Fan-out', async () => {
 	expect(await tracks[1]!.getDisplayHeight()).toBe(360);
 });
 
+test('Encoder resizing passes original-resolution frames through to the encoder', async () => {
+	using input = new Input({
+		source: new UrlSource('/video.mp4'),
+		formats: ALL_FORMATS,
+	});
+	const inputTrack = await input.getPrimaryVideoTrack();
+	assert(inputTrack);
+	const inputWidth = await inputTrack.getCodedWidth();
+	const inputHeight = await inputTrack.getCodedHeight();
+	const processedDimensions: { width: number; height: number }[] = [];
+
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+	const conversion = await Conversion.init({
+		input,
+		output,
+		video: {
+			height: 360,
+			resizeMode: 'encoder',
+			process: (sample) => {
+				processedDimensions.push({ width: sample.codedWidth, height: sample.codedHeight });
+				return sample;
+			},
+		},
+		audio: { discard: true },
+	});
+	await conversion.execute();
+
+	expect(processedDimensions.length).toBeGreaterThan(0);
+	expect(processedDimensions.every(x => x.width === inputWidth && x.height === inputHeight)).toBe(true);
+
+	using resizedInput = new Input({
+		source: new BufferSource(output.target.buffer!),
+		formats: ALL_FORMATS,
+	});
+	const resizedTrack = await resizedInput.getPrimaryVideoTrack();
+	assert(resizedTrack);
+	expect(await resizedTrack.getDisplayHeight()).toBe(360);
+});
+
 // eslint-disable-next-line @stylistic/max-len
 const aacPacketData = new Uint8Array([255, 241, 77, 128, 3, 159, 252, 0, 208, 0, 1, 3, 64, 0, 13, 0, 0, 17, 52, 0, 0, 208, 0, 3, 6, 128, 0, 56]);
 const aacMetadata: EncodedAudioChunkMetadata = {

--- a/test/browser/media-sources.test.ts
+++ b/test/browser/media-sources.test.ts
@@ -125,6 +125,36 @@ test('VideoSampleSource, same-sized frames with width and height set', async () 
 	input.dispose();
 });
 
+// eslint-disable-next-line @stylistic/max-len
+test('VideoSampleSource, encoder resize passes original frames to an encoder configured at the target size', async () => {
+	let encoderConfig: VideoEncoderConfig | undefined;
+	const encodedSampleDimensions: { width: number; height: number }[] = [];
+	const buffer = await encodeFrames(
+		{
+			codec: 'vp8',
+			quality: new Quality('medium'),
+			transform: { width: 50, height: 80, fit: 'fill', resizeMode: 'encoder' },
+			onEncoderConfig: config => encoderConfig = config,
+			onEncodedSample: sample => encodedSampleDimensions.push({
+				width: sample.codedWidth,
+				height: sample.codedHeight,
+			}),
+		},
+		[{ width: 100, height: 100 }, { width: 100, height: 100 }],
+	);
+
+	expect(encoderConfig).toMatchObject({ width: 50, height: 80 });
+	expect(encodedSampleDimensions).toEqual([
+		{ width: 100, height: 100 },
+		{ width: 100, height: 100 },
+	]);
+
+	const { input, track } = await readBackTrack(buffer);
+	expect(await track.getCodedWidth()).toBe(50);
+	expect(await track.getCodedHeight()).toBe(80);
+	input.dispose();
+});
+
 test('VideoSampleSource, same-sized frames with rotation set to 90', async () => {
 	const buffer = await encodeFrames(
 		{ codec: 'vp8', quality: new Quality('medium'), transform: { rotate: 90 } },

--- a/test/browser/media-sources.test.ts
+++ b/test/browser/media-sources.test.ts
@@ -155,6 +155,52 @@ test('VideoSampleSource, encoder resize passes original frames to an encoder con
 	input.dispose();
 });
 
+test('VideoSampleSource, encoder cover resize crops without a canvas transform', async () => {
+	const canvas = new OffscreenCanvas(200, 100);
+	const context = canvas.getContext('2d')!;
+	context.fillStyle = 'red';
+	context.fillRect(0, 0, 50, 100);
+	context.fillStyle = 'lime';
+	context.fillRect(50, 0, 100, 100);
+	context.fillStyle = 'blue';
+	context.fillRect(150, 0, 50, 100);
+
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+	const videoSource = new VideoSampleSource({
+		codec: 'vp8',
+		quality: new Quality('very-high'),
+		transform: { width: 100, height: 100, fit: 'cover', resizeMode: 'encoder' },
+	});
+	output.addVideoTrack(videoSource);
+	await output.start();
+
+	using sample = new VideoSample(canvas, { timestamp: 0, duration: 1 / 30 });
+	await videoSource.add(sample);
+	videoSource.close();
+	await output.finalize();
+
+	const { input, track } = await readBackTrack(output.target.buffer!);
+	expect(await track.getCodedWidth()).toBe(100);
+	expect(await track.getCodedHeight()).toBe(100);
+	const sink = new VideoSampleSink(track);
+	using decodedSample = await sink.getSample(0);
+	assert(decodedSample);
+
+	const decodedCanvas = new OffscreenCanvas(100, 100);
+	const decodedContext = decodedCanvas.getContext('2d')!;
+	decodedSample.draw(decodedContext, 0, 0);
+	const leftPixel = decodedContext.getImageData(10, 50, 1, 1).data;
+	const rightPixel = decodedContext.getImageData(90, 50, 1, 1).data;
+	expect(leftPixel[1]).toBeGreaterThan(200);
+	expect(leftPixel[0]).toBeLessThan(50);
+	expect(rightPixel[1]).toBeGreaterThan(200);
+	expect(rightPixel[2]).toBeLessThan(50);
+	input.dispose();
+});
+
 test('VideoSampleSource, same-sized frames with rotation set to 90', async () => {
 	const buffer = await encodeFrames(
 		{ codec: 'vp8', quality: new Quality('medium'), transform: { rotate: 90 } },


### PR DESCRIPTION
## Summary
- add an opt-in `resizeMode: 'encoder'` transform that passes original-resolution frames to WebCodecs and configures `VideoEncoder` at the target dimensions
- support `fill` directly and `cover` by cropping in the source pixel format with `VideoFrame.copyTo()` before encoder scaling, avoiding the Canvas/RGB transform path
- preserve existing Canvas behavior by default and fall back to it for transforms that the encoder path cannot handle

## Motivation
Canvas 2D `drawImage()` downscaling can discard substantial detail before the frame reaches the encoder, particularly for screen recordings with text and sharp UI edges. Increasing encoder quality cannot recover detail already lost during that resize. Letting `VideoEncoder` scale the original-resolution decoded frame avoids the Canvas resampling step and produced materially sharper output in our matched browser tests, with improved SSIM and PSNR at the same encoder quality.

## Test plan
- [x] `npm run check`
- [x] ESLint on the changed source and browser test files
- [x] browser tests for conversion and media sources (50 passed)
- [x] verify encoder configuration uses target dimensions while callbacks receive original-resolution samples
- [x] decode a cover-scaled fixture and verify the expected center crop