### PR TITLE
Write alternate_group 0 in ISOBMFF track headers

### DIFF
--- a/src/isobmff/isobmff-boxes.ts
+++ b/src/isobmff/isobmff-boxes.ts
@@ -501,7 +501,7 @@ export const tkhd = (
 		u32OrU64(durationInGlobalTimescale), // Duration
 		Array(8).fill(0), // Reserved
 		u16(0), // Layer
-		u16(trackData.track.id), // Alternate group
+		u16(0), // Alternate group
 		fixed_8_8(trackData.type === 'audio' ? 1 : 0), // Volume
 		u16(0), // Reserved
 		matrixToBytes(matrix), // Matrix

--- a/test/node/isobmff-muxer.test.ts
+++ b/test/node/isobmff-muxer.test.ts
@@ -387,3 +387,56 @@ test('At least one track is enabled even if all are added disabled', async () =>
 	expect((await tracks[0]!.getDisposition()).default).toBe(true);
 	expect((await tracks[1]!.getDisposition()).default).toBe(false);
 });
+
+test('Tracks are written with alternate_group 0', async () => {
+	const output = new Output({
+		format: new Mp4OutputFormat(),
+		target: new BufferTarget(),
+	});
+
+	const meta = { decoderConfig: { codec: 'vp8', codedWidth: 1280, codedHeight: 720 } };
+
+	const source1 = new EncodedVideoPacketSource('vp8');
+	output.addVideoTrack(source1);
+
+	const source2 = new EncodedVideoPacketSource('vp8');
+	output.addVideoTrack(source2);
+
+	await output.start();
+
+	await source1.add(new EncodedPacket(new Uint8Array(1024), 'key', 0, 0.1), meta);
+	await source2.add(new EncodedPacket(new Uint8Array(1024), 'key', 0, 0.1), meta);
+
+	await output.finalize();
+
+	const bytes = new Uint8Array(output.target.buffer!);
+	const view = new DataView(bytes.buffer);
+
+	// A non-zero alternate group marks the track as one of several selectable alternates
+	// (ISO 14496-12, 8.3.2.3). Players take that seriously: a video track in an alternate
+	// group makes Safari never auto-hide its media controls (#454). Walk moov > trak > tkhd
+	// and check the raw field, since the demuxer does not surface it.
+	const alternateGroups: number[] = [];
+	const walkBoxes = (start: number, end: number) => {
+		let pos = start;
+		while (pos + 8 <= end) {
+			const size = view.getUint32(pos);
+			if (size < 8 || pos + size > end) {
+				return;
+			}
+
+			const type = String.fromCharCode(bytes[pos + 4]!, bytes[pos + 5]!, bytes[pos + 6]!, bytes[pos + 7]!);
+			if (type === 'tkhd') {
+				const version = bytes[pos + 8]!;
+				alternateGroups.push(view.getUint16(pos + 8 + (version === 1 ? 46 : 34)));
+			} else if (type === 'moov' || type === 'trak') {
+				walkBoxes(pos + 8, pos + size);
+			}
+
+			pos += size;
+		}
+	};
+	walkBoxes(0, bytes.byteLength);
+
+	expect(alternateGroups).toEqual([0, 0]);
+});


### PR DESCRIPTION
Fixes #454.

## The bug

`tkhd()` wrote `alternate_group = track.id`, putting every track in its own singleton alternate group:

```js
u16(trackData.track.id), // Alternate group
```

Per ISO/IEC 14496-12 §8.3.2.3, a non-zero value marks tracks that "contain alternate data for one another"; 0 means "no information on possible relations to other tracks." A track alone in a non-zero group asserts a selection relationship with no other members. It conveys nothing, but players still act on it.

## What it breaks

Safari (26.5, macOS 26) never auto-hides its media controls over a file whose video track sits in an alternate group, both for an in-page `<video>` and in Safari's own `file://` viewer. The controls scrim stays composited over the picture for the entire playback, which users perceive as a washed-out grey video. Chrome, QuickTime Player, and Safari fullscreen are unaffected. AVFoundation appears to treat the video track as selectable alternative media, which keeps the controls' idle timer from ever engaging.

Confirmed by byte-level A/B in both directions on one H.264+AAC file pair: zeroing only the two `alternate_group` bytes in a mediabunny file and Safari hides the controls normally; setting only those bytes in an ffmpeg file (video → 1, audio → 2) and it stops. Everything else that differs from ffmpeg output was ruled out one variable at a time: chunk interleaving, timescales, edit lists, moov placement, cover art, `hdlr` fields, `sgpd`/`sbgp`, creation timestamps. Full bisect write-up: [Karaokio/cdg2mp4#85](https://github.com/Karaokio/cdg2mp4/pull/85).

We hit this in [cdg2mp4](https://cdg2mp4.com), a browser-only CDG+MP3 to MP4 karaoke converter that muxes with mediabunny; until this lands we patch the finalized buffer in place ([altGroups.ts](https://github.com/Karaokio/cdg2mp4/blob/main/src/lib/webcodecs/altGroups.ts)).

## Why 0

Apple's documentation of the [`alternate_group` field](https://developer.apple.com/documentation/quicktime-file-format/track_header_atom/alternate_group): "QuickTime chooses one track from the group to be used when the movie is played. ... A value of zero indicates that the track is not in an alternate track group." The worked example on that page shows the video track with Alternate Group ID 0, "which means that it is not in an alternate group."

ffmpeg's default ([movenc.c](https://github.com/FFmpeg/FFmpeg/blob/d9da090b1d05/libavformat/movenc.c#L4030-L4033)) is `group = st->codecpar->codec_type`: video 0, all audio tracks share group 1 (the multi-language use case). Per-track grouping exists there only behind the opt-in `per_stream_grouping` flag.

This PR writes 0 unconditionally. If you prefer ffmpeg's per-type convention (audio tracks as mutual alternates), that variant is `u16(trackData.type === 'audio' ? 1 : 0)` and is on [`alternate-group-ffmpeg-convention`](https://github.com/Vanilagy/mediabunny/compare/main...liladas:mediabunny:alternate-group-ffmpeg-convention) with its own test; I can switch this PR to it. Both variants are verified against Safari with real H.264+AAC files produced through each build. Exposing the field through track metadata for language alternates would also be an option. The only essential part is that a lone video track never gets a non-zero group.

## Test

Builds a two-track MP4 and walks the raw `moov > trak > tkhd` boxes, since the demuxer doesn't surface the field. Against the previous code it fails with `expected [ 1, 2 ] to deeply equal [ 0, 0 ]`. `npm run check`, `npm run lint`, and the full node suite (298 tests) pass.
