### PR TITLE
UrlSource: honor explicitly-set maxCacheSize in the no-range fallback

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -697,7 +697,12 @@ export type UrlSourceOptions = {
 	 */
 	getRetryDelay?: (previousAttempts: number, error: unknown, url: string | URL | Request) => number | null;
 
-	/** The maximum number of bytes the cache is allowed to hold in memory. Defaults to 64 MiB. */
+	/**
+	 * The maximum number of bytes the cache is allowed to hold in memory. Defaults to 64 MiB.
+	 *
+	 * This bound is always honored, even when the server doesn't support range requests. Note that in that case,
+	 * a backward seek to already-evicted data requires re-downloading the entire resource.
+	 */
 	maxCacheSize?: number;
 
 	/** The maximum number of parallel requests to use for fetching. Defaults to 2. */
@@ -968,7 +973,14 @@ export class UrlSource extends PathedSource {
 				}
 
 				worker.currentPos = 0;
-				this._orchestrator.options.maxCacheSize = Infinity; // 🤷
+
+				if (this._options.maxCacheSize === undefined) {
+					// Since the server ignores range requests, a backward seek past the eviction boundary would force
+					// us to re-download the entire resource from the start. We therefore lift the cache bound in this
+					// fallback mode - but only when the user didn't explicitly set maxCacheSize. An explicitly-set
+					// memory budget is always honored, accepting the risk of full re-downloads on backward seeks.
+					this._orchestrator.options.maxCacheSize = Infinity;
+				}
 
 				if (this._orchestrator.fileSize !== null) {
 					worker.targetPos = this._orchestrator.fileSize;

--- a/test/browser/url-source.test.ts
+++ b/test/browser/url-source.test.ts
@@ -61,6 +61,88 @@ test('Request with Range', async () => {
 	URL.revokeObjectURL(url);
 });
 
+const CHUNK_SIZE = 1024;
+const NO_RANGE_DATA_SIZE = 16 * CHUNK_SIZE;
+
+const makeNoRangeFetch = (data: Uint8Array, onFetch: () => void) => {
+	return (async () => {
+		onFetch();
+
+		// Always respond with the full resource, ignoring any Range header
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (let pos = 0; pos < data.length; pos += CHUNK_SIZE) {
+					controller.enqueue(data.subarray(pos, pos + CHUNK_SIZE));
+				}
+				controller.close();
+			},
+		});
+
+		return new Response(stream, {
+			status: 200,
+			headers: { 'Content-Length': String(data.length) },
+		});
+	}) as typeof fetch;
+};
+
+const makeNoRangeData = () => {
+	const data = new Uint8Array(NO_RANGE_DATA_SIZE);
+	for (let i = 0; i < data.length; i++) {
+		data[i] = i % 256;
+	}
+	return data;
+};
+
+test('Explicitly set maxCacheSize is honored when the server does not support range requests', async () => {
+	const data = makeNoRangeData();
+	let fetchCount = 0;
+
+	const source = new UrlSource('https://example.com/no-range-support', {
+		maxCacheSize: 4 * CHUNK_SIZE,
+		fetchFn: makeNoRangeFetch(data, () => fetchCount++),
+	});
+	const reader = new Reader(source);
+
+	// Read the entire resource sequentially, which engages the fallback
+	const full = await reader.requestSlice(0, data.length);
+	expect(full).not.toBeNull();
+	expect([...readBytes(full!, data.length)]).toEqual([...data]);
+
+	// The explicit cache bound must have been kept, meaning early data got evicted during the sequential read
+	expect(source._orchestrator.options.maxCacheSize).toBe(4 * CHUNK_SIZE);
+
+	// A backward read to evicted data must still return correct bytes, but requires re-downloading the resource
+	const before = fetchCount;
+	const slice = await reader.requestSlice(0, CHUNK_SIZE);
+	expect(slice).not.toBeNull();
+	expect([...readBytes(slice!, CHUNK_SIZE)]).toEqual([...data.subarray(0, CHUNK_SIZE)]);
+	expect(fetchCount).toBe(before + 1);
+});
+
+test('Default cache bound is lifted when the server does not support range requests', async () => {
+	const data = makeNoRangeData();
+	let fetchCount = 0;
+
+	const source = new UrlSource('https://example.com/no-range-support', {
+		fetchFn: makeNoRangeFetch(data, () => fetchCount++),
+	});
+	const reader = new Reader(source);
+
+	// Read the entire resource sequentially, which engages the fallback
+	const full = await reader.requestSlice(0, data.length);
+	expect(full).not.toBeNull();
+	expect([...readBytes(full!, data.length)]).toEqual([...data]);
+
+	// With no explicit cache bound, the cache must have been made unbounded to avoid re-downloads
+	expect(source._orchestrator.options.maxCacheSize).toBe(Infinity);
+
+	// A backward read is then served from the cache without an additional request
+	const slice = await reader.requestSlice(0, CHUNK_SIZE);
+	expect(slice).not.toBeNull();
+	expect([...readBytes(slice!, CHUNK_SIZE)]).toEqual([...data.subarray(0, CHUNK_SIZE)]);
+	expect(fetchCount).toBe(1);
+});
+
 const makeRampedUrl = () => {
 	const data = new Uint8Array(256);
 	for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
Fixes #457.

When the server doesn't answer a Range request with 206, UrlSource falls back to streaming the entire resource through one worker and previously forced `maxCacheSize = Infinity` — silently discarding a memory bound the caller explicitly opted into, which can mean OOM instead of degraded performance for multi-GB inputs.

**Change:** the fallback now only lifts the cache bound when `maxCacheSize` was *not* explicitly provided. Default behavior is unchanged: with an unbounded cache, backward seeks never trigger a full re-download (which is why the bound was lifted in the first place — with a bounded cache, a backward seek past the eviction boundary forces re-downloading the entire resource, since the server ignores range requests). A caller who explicitly sets `maxCacheSize` gets their memory budget honored and accepts that trade-off — this is option 2 from the issue.

Also documents the behavior in the `maxCacheSize` docblock.

**Tests:** two new cases in `test/browser/url-source.test.ts` using a `fetchFn` stub that always responds `200` (ignoring `Range`) and streams a 16 KiB resource in 1 KiB chunks:

- explicit `maxCacheSize` is preserved through the fallback, sequential reads evict as usual, and a backward read to evicted data still returns correct bytes (via one additional fetch)
- without an explicit bound, the cache still becomes unbounded and backward reads are served from cache with no additional request

Verified: `npm run check`, ESLint on changed files, and the new test logic executed against `src/` directly. I couldn't run the headed-browser suite locally, so the browser tests should run in CI.
