### PR TITLE
Guard decoder close against already-closed codecs (completes the #446 fix)

### DIFF
--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -874,6 +874,7 @@ class VideoDecoderWrapper extends DecoderWrapper<VideoSample> {
 
 	customDecoder: CustomVideoDecoder | null = null;
 	customDecoderCallSerializer = new CallSerializer();
+	customDecoderClosed = false;
 	customDecoderQueueSize = 0;
 
 	inputTimestamps: number[] = []; // Timestamps input into the decoder, sorted.
@@ -1294,11 +1295,21 @@ class VideoDecoderWrapper extends DecoderWrapper<VideoSample> {
 
 	close() {
 		if (this.customDecoder) {
-			void this.customDecoderCallSerializer.call(() => this.customDecoder!.close());
+			if (!this.customDecoderClosed) {
+				this.customDecoderClosed = true;
+				void this.customDecoderCallSerializer.call(() => this.customDecoder!.close());
+			}
 		} else {
 			assert(this.decoder);
-			this.decoder.close();
-			this.alphaDecoder?.close();
+
+			// The codec may already be closed: when the platform fails a decoder, the spec closes it before invoking
+			// the error callback, and close() on a closed codec throws InvalidStateError.
+			if (this.decoder.state !== 'closed') {
+				this.decoder.close();
+			}
+			if (this.alphaDecoder && this.alphaDecoder.state !== 'closed') {
+				this.alphaDecoder.close();
+			}
 
 			this.colorQueue.forEach(x => x.close());
 			this.colorQueue.length = 0;
@@ -2065,6 +2076,7 @@ class AudioDecoderWrapper extends DecoderWrapper<AudioSample> {
 
 	customDecoder: CustomAudioDecoder | null = null;
 	customDecoderCallSerializer = new CallSerializer();
+	customDecoderClosed = false;
 	customDecoderQueueSize = 0;
 
 	// Internal state to accumulate a precise current timestamp based on audio durations, not the (potentially
@@ -2199,10 +2211,17 @@ class AudioDecoderWrapper extends DecoderWrapper<AudioSample> {
 
 	close() {
 		if (this.customDecoder) {
-			void this.customDecoderCallSerializer.call(() => this.customDecoder!.close());
+			if (!this.customDecoderClosed) {
+				this.customDecoderClosed = true;
+				void this.customDecoderCallSerializer.call(() => this.customDecoder!.close());
+			}
 		} else {
 			assert(this.decoder);
-			this.decoder.close();
+
+			// See the comment in VideoDecoderWrapper.close().
+			if (this.decoder.state !== 'closed') {
+				this.decoder.close();
+			}
 		}
 	}
 }

--- a/test/browser/media-sinks.test.ts
+++ b/test/browser/media-sinks.test.ts
@@ -3,7 +3,7 @@ import { Input } from '../../src/input.js';
 import { UrlSource } from '../../src/source.js';
 import { ALL_FORMATS } from '../../src/input-format.js';
 import { assert } from '../../src/misc.js';
-import { AudioSampleSink } from '../../src/media-sink.js';
+import { AudioSampleSink, VideoSampleSink } from '../../src/media-sink.js';
 
 // https://github.com/Vanilagy/mediabunny/issues/370
 test('Negative audio timestamps are preserved', async () => {
@@ -23,4 +23,77 @@ test('Negative audio timestamps are preserved', async () => {
 		expect(sample.timestamp).toBe(await track.getFirstTimestamp());
 		break;
 	}
+});
+
+// A decoder the platform fails is already closed by the time the pump's finally block closes it: per the Close
+// VideoDecoder algorithm, [[state]] becomes "closed" (step 2) before the error callback is invoked (step 4). Closing it
+// again throws InvalidStateError inside a promise chain nobody holds, which no consumer can catch.
+test('A platform-closed decoder does not produce an uncatchable rejection', async () => {
+	const RealVideoDecoder = globalThis.VideoDecoder;
+	let decodesUntilFailure = 3;
+
+	class PlatformFailingVideoDecoder extends RealVideoDecoder {
+		private readonly errorCallback: VideoDecoderInit['error'];
+
+		constructor(init: VideoDecoderInit) {
+			super(init);
+			this.errorCallback = init.error;
+		}
+
+		override decode(chunk: EncodedVideoChunk) {
+			if (decodesUntilFailure > 0) {
+				decodesUntilFailure--;
+				super.decode(chunk);
+				return;
+			}
+
+			// Mimic the platform: close the codec first, then report the error.
+			if (this.state !== 'closed') {
+				super.close();
+			}
+
+			this.errorCallback(new DOMException('Simulated decoding error.', 'EncodingError'));
+		}
+	}
+
+	const rejections: unknown[] = [];
+	const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+		rejections.push(event.reason);
+		event.preventDefault();
+	};
+
+	window.addEventListener('unhandledrejection', onUnhandledRejection);
+	globalThis.VideoDecoder = PlatformFailingVideoDecoder;
+
+	let caught: unknown = null;
+
+	try {
+		using input = new Input({
+			source: new UrlSource('/video.mp4'),
+			formats: ALL_FORMATS,
+		});
+
+		const track = await input.getPrimaryVideoTrack();
+		assert(track);
+
+		const sink = new VideoSampleSink(track);
+
+		try {
+			for await (const sample of sink.samples()) {
+				sample.close();
+			}
+		} catch (error) {
+			caught = error;
+		}
+	} finally {
+		globalThis.VideoDecoder = RealVideoDecoder;
+		// unhandledrejection is queued as a task, so give it one to land in
+		await new Promise(resolve => setTimeout(resolve, 500));
+		window.removeEventListener('unhandledrejection', onUnhandledRejection);
+	}
+
+	// The consumer must see the decode failure through the iterator...
+	expect(caught).toBeInstanceOf(DOMException);
+	// ...and that must be the only place it surfaces.
+	expect(rejections).toEqual([]);
 });


### PR DESCRIPTION
`90ec401` (fixes #446) moved `decoder.close()` into a `.finally()` around both
sink pumps. The codec may already be closed by the time that runs, and
`DecoderWrapper.close()` closes it unguarded.

When the platform fails a decoder,
[Close VideoDecoder](https://www.w3.org/TR/webcodecs/) sets `[[state]]` to
`"closed"` at step 2 and invokes the error callback at step 4. So:

1. `error:` fires at `media-sink.ts:972`, records `outOfBandError`, doesn't throw.
2. The pump's next `decode()`/`flush()` rejects against the closed codec.
3. `.finally()` at `:814` (and `:587`) calls `decoder?.close()`.
4. `VideoDecoderWrapper.close()` at `:1300` closes an already-closed codec →
   `InvalidStateError`.

That throw lands in a promise chain nobody holds, so it becomes an unhandled
rejection no consumer can catch — not with `try/catch` around iteration, not
through the sink's own error plumbing. `AudioDecoderWrapper.close()` at `:2205`
is the same shape.

#446 predicted it:

> It has to be moved rather than added — `DecoderWrapper.close()` calls
> `this.decoder.close()` unguarded, so a second call would throw
> `InvalidStateError`.

Moving it stops Mediabunny double-closing its own codec, but not the platform
closing it first.

Affects 1.52.0 through 1.54.0.

## Fix

The guard you already use on the encoder side (`media-source.ts:979-983`) and on
the decoder side in `v2` (`decode.ts`):

- `VideoDecoderWrapper.close()` — check `state !== 'closed'` for `decoder` and
  `alphaDecoder`, and make the custom-decoder path idempotent.
- `AudioDecoderWrapper.close()` — same.

Nothing changes where the codec is still open.

## How we hit it

`CanvasSink.getCanvas(t)` driven concurrently past the machine's hardware decoder
ceiling. Measured with `@motionvector/webcodecs-census`, our WebCodecs lifecycle
instrumentation, over CDP — Chrome for Testing 152, two 1080p H.264 clips:

| | |
| --- | --- |
| decoders constructed in 7.5s | 1233 |
| platform decode errors | 402 |
| `close()` on an already-closed codec | 148 |
| unhandled rejections | 175 |

The 1233 decoders were our bug, and bounding concurrency fixed our side. The
uncatchable rejection is reachable from any decode error, and it's the part a
consumer can't work around.

## Test

`test/browser/media-sinks.test.ts` stubs `VideoDecoder` so a decode closes the
codec and then invokes the error callback, matching the spec order. It asserts
the consumer still sees the failure through the iterator, and that nothing else
escapes.

Fails without the guard, passes with it. `expect(caught).toBeInstanceOf(DOMException)`
holds in both arms, so consumers observe no change.

`npm run lint`, `npm run check` and `npm run test-node` (360/360) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
