### PR TITLE
Use AVC SPS color space when ISOBMFF colr is missing

### DIFF
--- a/src/codec-data.ts
+++ b/src/codec-data.ts
@@ -502,6 +502,8 @@ export type AvcSpsInfo = {
 	transferCharacteristics: number;
 	matrixCoefficients: number;
 	fullRangeFlag: number;
+	videoSignalTypePresentFlag: number;
+	colourDescriptionPresentFlag: number;
 	numReorderFrames: number;
 	maxDecFrameBuffering: number;
 };
@@ -657,6 +659,8 @@ export const parseAvcSps = (sps: Uint8Array): AvcSpsInfo | null => {
 		let transferCharacteristics = 2;
 		let matrixCoefficients = 2;
 		let fullRangeFlag = 0;
+		let videoSignalTypePresentFlag = 0;
+		let colourDescriptionPresentFlag = 0;
 		let pixelAspectRatio: Rational = { num: 1, den: 1 };
 
 		let numReorderFrames: number | null = null;
@@ -686,11 +690,11 @@ export const parseAvcSps = (sps: Uint8Array): AvcSpsInfo | null => {
 				bitstream.skipBits(1); // overscan_appropriate_flag
 			}
 
-			const videoSignalTypePresentFlag = bitstream.readBits(1);
+			videoSignalTypePresentFlag = bitstream.readBits(1);
 			if (videoSignalTypePresentFlag) {
 				bitstream.skipBits(3); // video_format
 				fullRangeFlag = bitstream.readBits(1);
-				const colourDescriptionPresentFlag = bitstream.readBits(1);
+				colourDescriptionPresentFlag = bitstream.readBits(1);
 				if (colourDescriptionPresentFlag) {
 					colourPrimaries = bitstream.readBits(8);
 					transferCharacteristics = bitstream.readBits(8);
@@ -793,6 +797,8 @@ export const parseAvcSps = (sps: Uint8Array): AvcSpsInfo | null => {
 			matrixCoefficients,
 			transferCharacteristics,
 			fullRangeFlag,
+			videoSignalTypePresentFlag,
+			colourDescriptionPresentFlag,
 			numReorderFrames,
 			maxDecFrameBuffering,
 		};

--- a/src/isobmff/isobmff-demuxer.ts
+++ b/src/isobmff/isobmff-demuxer.ts
@@ -41,6 +41,8 @@ import {
 	AC3_ACMOD_CHANNEL_COUNTS,
 	extractAvcDecoderConfigurationRecord,
 	extractHevcDecoderConfigurationRecord,
+	deserializeAvcDecoderConfigurationRecord,
+	parseAvcSps,
 } from '../codec-data';
 import { Demuxer } from '../demuxer';
 import { Input } from '../input';
@@ -3409,12 +3411,51 @@ class IsobmffVideoTrackBacking extends IsobmffTrackBacking implements InputVideo
 		return this.internalTrack.rotation;
 	}
 
-	async getColorSpace(): Promise<VideoColorSpaceInit> {
+	private getEffectiveColorSpace(): VideoColorSpaceInit | null {
+		if (this.internalTrack.info.colorSpace) {
+			return this.internalTrack.info.colorSpace;
+		}
+		if (this.internalTrack.info.codec !== 'avc') {
+			return null;
+		}
+
+		const codecInfo = this.internalTrack.info.avcCodecInfo
+			?? (this.internalTrack.info.codecDescription
+				? deserializeAvcDecoderConfigurationRecord(this.internalTrack.info.codecDescription)
+				: null);
+		const sps = codecInfo?.sequenceParameterSets[0];
+		if (!sps) {
+			return null;
+		}
+
+		const spsInfo = parseAvcSps(sps);
+		if (!spsInfo?.videoSignalTypePresentFlag) {
+			return null;
+		}
+
 		return {
-			primaries: this.internalTrack.info.colorSpace?.primaries,
-			transfer: this.internalTrack.info.colorSpace?.transfer,
-			matrix: this.internalTrack.info.colorSpace?.matrix,
-			fullRange: this.internalTrack.info.colorSpace?.fullRange,
+			primaries: spsInfo.colourDescriptionPresentFlag
+				? (COLOR_PRIMARIES_MAP_INVERSE[spsInfo.colourPrimaries] as VideoColorPrimaries | undefined)
+				: undefined,
+			transfer: spsInfo.colourDescriptionPresentFlag
+				? (TRANSFER_CHARACTERISTICS_MAP_INVERSE[spsInfo.transferCharacteristics] as
+					VideoTransferCharacteristics | undefined)
+				: undefined,
+			matrix: spsInfo.colourDescriptionPresentFlag
+				? (MATRIX_COEFFICIENTS_MAP_INVERSE[spsInfo.matrixCoefficients] as
+					VideoMatrixCoefficients | undefined)
+				: undefined,
+			fullRange: Boolean(spsInfo.fullRangeFlag),
+		};
+	}
+
+	async getColorSpace(): Promise<VideoColorSpaceInit> {
+		const colorSpace = this.getEffectiveColorSpace();
+		return {
+			primaries: colorSpace?.primaries,
+			transfer: colorSpace?.transfer,
+			matrix: colorSpace?.matrix,
+			fullRange: colorSpace?.fullRange,
 		};
 	}
 
@@ -3452,7 +3493,7 @@ class IsobmffVideoTrackBacking extends IsobmffTrackBacking implements InputVideo
 				codedWidth: this.internalTrack.info.width,
 				codedHeight: this.internalTrack.info.height,
 				description: this.internalTrack.info.codecDescription ?? undefined,
-				colorSpace: this.internalTrack.info.colorSpace ?? undefined,
+				colorSpace: this.getEffectiveColorSpace() ?? undefined,
 			};
 
 			if (

--- a/test/node/read-mp4.test.ts
+++ b/test/node/read-mp4.test.ts
@@ -95,6 +95,27 @@ test('MP4 nclx color information', async () => {
 	expect(await track.hasHighDynamicRange()).toBe(true);
 });
 
+test('MP4 AVC SPS color information is used when nclx/nclc is missing', async () => {
+	const filePath = path.join(__dirname, '..', 'public/video.mp4');
+	using input = new Input({
+		source: new FilePathSource(filePath),
+		formats: ALL_FORMATS,
+	});
+
+	const track = await input.getPrimaryVideoTrack();
+	if (!track) throw new Error('No video track found');
+
+	const expectedColorSpace = {
+		primaries: undefined,
+		transfer: undefined,
+		matrix: 'bt470bg',
+		fullRange: true,
+	};
+
+	expect(await track.getColorSpace()).toEqual(expectedColorSpace);
+	expect((await track.getDecoderConfig())?.colorSpace).toEqual(expectedColorSpace);
+});
+
 test('QuickTime nclc color information', async () => {
 	const output = new Output({
 		format: new MovOutputFormat(),
@@ -156,6 +177,7 @@ test('Annex B', async () => {
 	const decoderConfig = (await track.getDecoderConfig())!;
 	expect(decoderConfig.codec).toBe('avc1.424028');
 	expect(decoderConfig.description).toBeUndefined();
+	expect(decoderConfig.colorSpace).toBeUndefined();
 
 	const sink = new EncodedPacketSink(track);
 	const firstPacket = (await sink.getFirstPacket())!;


### PR DESCRIPTION
Fixes https://github.com/Vanilagy/mediabunny/issues/474

## Summary

- fall back to AVC SPS/VUI color metadata when ISO-BMFF has no `nclx`/`nclc` color box
- preserve container color metadata precedence and leave absent VUI fields unspecified
- pass the derived color space to `VideoDecoderConfig`

## Tests

- `npm test` (55 files, 514 tests)
- `npm run check`
- `npm run lint`
- `npm run build`
- verified the public issue reproduction reports `matrix: "bt470bg"` and `fullRange: true` for both the track and decoder config
