### PR TITLE
Terminate sample iterators before throwing so late-decoded samples are closed

### DIFF
--- a/src/media-sink.ts
+++ b/src/media-sink.ts
@@ -601,11 +601,18 @@ export abstract class BaseMediaSampleSink<
 			async next() {
 				while (true) {
 					if (track.input._disposed) {
+						// Once next() throws, the consumer will never call return(), so terminate the
+						// iteration here - otherwise, the pump keeps queueing decoded samples that
+						// nothing can ever close.
+						terminated = true;
+						ended = true;
 						closeSamples();
 						throw new InputDisposedError();
 					} else if (terminated) {
 						return { value: undefined, done: true };
 					} else if (hasOutOfBandError) {
+						terminated = true;
+						ended = true;
 						closeSamples();
 						throw outOfBandError;
 					} else if (sampleQueue.length > 0) {
@@ -827,11 +834,16 @@ export abstract class BaseMediaSampleSink<
 			async next() {
 				while (true) {
 					if (track.input._disposed) {
+						// Once next() throws, the consumer will never call return(), so terminate the
+						// iteration here - otherwise, the pump keeps queueing decoded samples that
+						// nothing can ever close.
+						terminated = true;
 						closeSamples();
 						throw new InputDisposedError();
 					} else if (terminated) {
 						return { value: undefined, done: true };
 					} else if (hasOutOfBandError) {
+						terminated = true;
 						closeSamples();
 						throw outOfBandError;
 					} else if (sampleQueue.length > 0) {


### PR DESCRIPTION
## Problem

In both sample generators in `src/media-sink.ts` (`mediaSamplesInRange` and `mediaSamplesAtTimestamps`), the `next()` error branches throw without setting `terminated`:

```ts
if (track.input._disposed) {
    closeSamples();
    throw new InputDisposedError();
} else if (hasOutOfBandError) {
    closeSamples();
    throw outOfBandError;
}
```

Per the language spec, `for await` does **not** call `return()` on an iterator whose `next()` threw — the iterator is simply abandoned. Since `terminated` (and `ended` in `mediaSamplesInRange`) stays `false`, the pump's decoder callback keeps pushing decoded samples into `sampleQueue` after the throw. No consumer will ever call `next()` again, `closeSamples()` already ran, and `return()` will never be called — those samples are orphaned until GC ("A VideoSample was garbage collected without first being closed"). This is the throw-path sibling of #80, which fixed cleanup for the `break`/`return()` path.

## Real-world impact

On iOS Safari, the hardware `VideoDecoder` can die mid-iteration under memory pressure (native error: `Decoding task did not complete`), which surfaces exactly through the out-of-band error path. Each orphaned `VideoSample` pins a GPU-backed `VideoFrame` until GC, so on a memory-pressured device the decoder failure *amplifies* the very pressure that caused it. We hit this in a multi-track video editor during heavy scrubbing, where it fed into further decoder failures and WebGL context losses.

Measured on-device (iPhone, iOS 18.7, six 1080p sources) with create/close accounting instrumentation on `VideoSample`: **3–14 samples orphaned per failing iterator per decoder-death event**, permanently (the created−closed residual never recovers). Note the `A VideoSample was garbage collected…` log is rate-limited to 1/s, so observed warning counts understate the leak.

## Fix

Set the termination flags before throwing, in the `InputDisposedError` and out-of-band error branches of both generators (`ended` too in `mediaSamplesInRange`, whose pump callback gates on it). Samples emitted by the decoder callback after the throw are then closed on arrival by the existing `terminated`/`ended` checks.

Verified on-device under the same reproduction: orphans dropped from 3–14 per iterator to **≤1**.

## Known residual

A sample materializing between the error being recorded and the consumer's `next()` running (i.e. already in flight inside the decoder wrapper during that microtask window) can still slip through — we consistently saw at most one per event. Closing that fully would need the pump to re-run `closeSamples()` once the consumer is known to be gone; this one-line-per-branch fix removes the unbounded part of the leak. Happy to extend the patch if you'd prefer that too.

`npx tsc --noEmit` and `eslint` pass on the changed file.